### PR TITLE
More efficient `DELETE` queries

### DIFF
--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -137,15 +137,18 @@ namespace olu::config::constants {
     };
 
     const static inline std::vector<std::string> PREFIXES_FOR_NODE_DELETE_QUERY {
-        "PREFIX osmnode: <https://www.openstreetmap.org/node/>"
+        "PREFIX osmnode: <https://www.openstreetmap.org/node/>",
+        "PREFIX ogc: <http://www.opengis.net/rdf#>"
     };
 
     const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_QUERY {
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>"
+            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
+            "PREFIX ogc: <http://www.opengis.net/rdf#>"
     };
 
     const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_QUERY {
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>"
+            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
+            "PREFIX ogc: <http://www.opengis.net/rdf#>"
     };
 
     const static inline std::vector<std::string> PREFIXES_FOR_WAYS_REFERENCING_NODE {

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -54,8 +54,7 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
     }
 
     ss << "} ";
-    ss << wrapWithGraphOptional("?s ?p1 ?o1 . OPTIONAL { ?o1 ?p2 ?o2. }");
-    ss << " }";
+    ss << wrapWithGraphOptional("?s ?p1 ?o1 FILTER (! STRSTARTS(?p1, ogc:)) . OPTIONAL { ?o1 ?p2 ?o2. }"); ss << " }";
     return ss.str();
 }
 


### PR DESCRIPTION
As they are currently, the `DELETE` query run out of memory already for medium-sized datasets like Freiburg Regbez. This change `FILTER`s out the `ogc:sf...` triples which cause the excessive memory usage and are even wrong.