### PR TITLE
Avoid blank nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ include_directories(SYSTEM ${POPL_INCLUDE_DIR})
 
 FetchContent_Declare(osm2rdf
         GIT_REPOSITORY  https://github.com/nicolano/osm2rdf.git
-        GIT_TAG 3ef86ff9ad22bf7ee3a60192c1e8473bb8432d33
+        GIT_TAG 1c1f0d1697d9af283675c13d2a0f311f5eaa8a80
 )
 FetchContent_MakeAvailable(osm2rdf)
 include_directories(SYSTEM ${osm2rdf_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,8 @@ find_package(POPL REQUIRED)
 include_directories(SYSTEM ${POPL_INCLUDE_DIR})
 
 FetchContent_Declare(osm2rdf
-        GIT_REPOSITORY  https://github.com/ad-freiburg/osm2rdf.git
-        GIT_TAG 07a9f65216f6df2fce5d064156e6d15903e8ccfd
+        GIT_REPOSITORY  https://github.com/nicolano/osm2rdf.git
+        GIT_TAG 3ef86ff9ad22bf7ee3a60192c1e8473bb8432d33
 )
 FetchContent_MakeAvailable(osm2rdf)
 include_directories(SYSTEM ${osm2rdf_SOURCE_DIR}/include)

--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -52,6 +52,9 @@ struct Config {
     // User specified timestamp from command line
     std::string timestamp;
 
+    // Specifies if osm2rdf should be run with the option to mask blank nodes
+    bool noBlankNodes = false;
+
     // Specifies whether a progress bar should be shown
     bool showProgress = true;
 

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -92,6 +92,7 @@ namespace olu::config::constants {
         "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>"
         "PREFIX osm2rdfkey: <https://osm2rdf.cs.uni-freiburg.de/rdf/key#>"
         "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
+        "PREFIX genid: <http://osm2rdf.cs.uni-freiburg.de/.well-known/genid/>"
         "PREFIX ohmway: <https://www.openhistoricalmap.org/way/>"
         "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
         "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
@@ -239,6 +240,12 @@ namespace olu::config::constants {
     const static inline std::string TIME_STAMP_OPTION_LONG = "timestamp";
     const static inline std::string TIME_STAMP_OPTION_HELP =
             "The time stamp to start the update process from.";
+
+    const static inline std::string BLANK_NODES_INFO = "Blank nodes are masked";
+    const static inline std::string BLANK_NODES_OPTION_SHORT = "";
+    const static inline std::string BLANK_NODES_OPTION_LONG = "no-blank-nodes";
+    const static inline std::string BLANK_NODES_OPTION_HELP =
+        "Avoid blank nodes by using a unique identifier for each member";
 
 } // namespace olu::config::constants
 

--- a/include/osm/Osm2ttl.h
+++ b/include/osm/Osm2ttl.h
@@ -30,7 +30,7 @@ namespace olu::osm {
         explicit Osm2ttl(const olu::config::Config &config);
 
         // Converts osm data to ttl triplets
-        [[nodiscard]] std::filesystem::path convert() const;
+        void convert() const;
     private:
         olu::config::Config _config;
 

--- a/include/osm/Osm2ttl.h
+++ b/include/osm/Osm2ttl.h
@@ -19,6 +19,7 @@
 #ifndef OSM_LIVE_UPDATES_OSM2TTL_H
 #define OSM_LIVE_UPDATES_OSM2TTL_H
 
+#include <config/Config.h>
 #include <osm2rdf/config/Config.h>
 #include <osm2rdf/util/Output.h>
 
@@ -26,9 +27,13 @@ namespace olu::osm {
 
     class Osm2ttl {
     public:
+        explicit Osm2ttl(const olu::config::Config &config);
+
         // Converts osm data to ttl triplets
-        static std::filesystem::path convert() ;
+        [[nodiscard]] std::filesystem::path convert() const;
     private:
+        olu::config::Config _config;
+
         template <typename T>
         static void run(const osm2rdf::config::Config& config);
         static void writeToInputFile();

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -82,6 +82,11 @@ void olu::config::Config::fromArgs(int argc, char **argv) {
             olu::config::constants::SEQUENCE_NUMBER_OPTION_LONG,
             olu::config::constants::SEQUENCE_NUMBER_OPTION_HELP);
 
+    auto noBlankNodesOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+            olu::config::constants::BLANK_NODES_OPTION_SHORT,
+            olu::config::constants::BLANK_NODES_OPTION_LONG,
+            olu::config::constants::BLANK_NODES_OPTION_HELP);
+
     try {
         parser.parse(argc, argv);
 
@@ -159,6 +164,8 @@ void olu::config::Config::fromArgs(int argc, char **argv) {
         if (sparqlAccessTokenOp->is_set()) {
             accessToken = sparqlAccessTokenOp->value();
         }
+
+        noBlankNodes = noBlankNodesOp->is_set();
 
         if (sparqlUpdateUri->is_set()) {
             sparqlEndpointUriForUpdates = sparqlUpdateUri->value();
@@ -280,13 +287,11 @@ std::string olu::config::Config::getInfo(std::string_view prefix) const {
         }
     }
 
-    if (sparqlOutput != ENDPOINT) {
+    if (noBlankNodes) {
         oss
         << osm2rdf::util::currentTimeFormatted()
         << prefix
-        << olu::config::constants::SPARQL_OUTPUT_INFO
-        << " "
-        << sparqlOutputFile
+        << olu::config::constants::BLANK_NODES_INFO
         << std::endl;
     }
 

--- a/src/osm/Osm2ttl.cpp
+++ b/src/osm/Osm2ttl.cpp
@@ -52,7 +52,6 @@ namespace olu::osm {
                        cnst::PATH_TO_OUTPUT_FILE,
                        "-t",
                        cnst::PATH_TO_SCRATCH_DIRECTORY,
-                       "--" + osm2rdf::config::constants::UNTAGGED_NODES_SPATIAL_RELS_OPTION_LONG,
                        "--" + osm2rdf::config::constants::OUTPUT_COMPRESS_OPTION_LONG,
                        "none",
                        "--" + osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_LONG,

--- a/src/osm/Osm2ttl.cpp
+++ b/src/osm/Osm2ttl.cpp
@@ -33,9 +33,10 @@
 namespace cnst = olu::config::constants;
 
 namespace olu::osm {
+    Osm2ttl::Osm2ttl(const olu::config::Config& config) : _config(config) {}
 
     // _____________________________________________________________________________________________
-    std::filesystem::path Osm2ttl::convert() {
+    std::filesystem::path Osm2ttl::convert() const {
         writeToInputFile();
 
         // Create a directory for scratch, if not already existent
@@ -57,6 +58,11 @@ namespace olu::osm {
                        "--" + osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_LONG,
                        "none"
                        };
+
+        if (_config.noBlankNodes) {
+            arguments.emplace_back("--" + osm2rdf::config::constants::BLANK_NODES_OPTION_LONG);
+        }
+
         std::vector<char*> argv;
         for (const auto& arg : arguments) {
             argv.push_back((char*)arg.data());

--- a/src/osm/Osm2ttl.cpp
+++ b/src/osm/Osm2ttl.cpp
@@ -36,7 +36,7 @@ namespace olu::osm {
     Osm2ttl::Osm2ttl(const olu::config::Config& config) : _config(config) {}
 
     // _____________________________________________________________________________________________
-    std::filesystem::path Osm2ttl::convert() const {
+    void Osm2ttl::convert() const {
         writeToInputFile();
 
         // Create a directory for scratch, if not already existent
@@ -91,8 +91,6 @@ namespace olu::osm {
             std::cerr << e.what() << std::endl;
             std::exit(osm2rdf::config::ExitCode::EXCEPTION);
         }
-
-        return config.output;
     }
 
     // _____________________________________________________________________________________________

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -98,8 +98,7 @@ namespace olu::osm {
 
         // Convert osm objects to triples
         try {
-            Osm2ttl osm2ttl(_config);
-            osm2ttl.convert();
+            Osm2ttl(_config).convert();
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             throw OsmChangeHandlerException(
@@ -162,7 +161,7 @@ namespace olu::osm {
     }
 
     void OsmChangeHandler::storeIdsOfElementsInChangeFile() {
-        for (const auto &[changesetTag, changesetElement] : _osmChangeElement) {
+        for (const auto &[changesetTag, changesetElement]: _osmChangeElement) {
             if (changesetTag == "<xmlattr>") { continue; }
 
             for (const auto &[elementTag, element]: changesetElement) {

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -98,7 +98,8 @@ namespace olu::osm {
 
         // Convert osm objects to triples
         try {
-            Osm2ttl::convert();
+            Osm2ttl osm2ttl(_config);
+            osm2ttl.convert();
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             throw OsmChangeHandlerException(

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -457,6 +457,7 @@ namespace olu::osm {
         std::set<id_t> nodesToDelete;
         nodesToDelete.insert(_deletedNodes.begin(), _deletedNodes.end());
         nodesToDelete.insert(_modifiedNodes.begin(), _modifiedNodes.end());
+        nodesToDelete.insert(_createdNodes.begin(), _createdNodes.end());
 
         doInBatches(
             nodesToDelete,
@@ -474,6 +475,7 @@ namespace olu::osm {
         waysToDelete.insert(_deletedWays.begin(), _deletedWays.end());
         waysToDelete.insert(_modifiedWays.begin(), _modifiedWays.end());
         waysToDelete.insert(_waysToUpdateGeometry.begin(), _waysToUpdateGeometry.end());
+        waysToDelete.insert(_createdWays.begin(), _createdWays.end());
 
         doInBatches(
             waysToDelete,
@@ -492,6 +494,7 @@ namespace olu::osm {
         relationsToDelete.insert(_modifiedRelations.begin(), _modifiedRelations.end());
         relationsToDelete.insert(_relationsToUpdateGeometry.begin(),
                                  _relationsToUpdateGeometry.end());
+        relationsToDelete.insert(_createdRelations.begin(), _createdRelations.end());
 
         doInBatches(
             relationsToDelete,

--- a/src/osm/OsmDataFetcher.cpp
+++ b/src/osm/OsmDataFetcher.cpp
@@ -117,7 +117,7 @@ namespace olu::osm {
             std::string locationAsWkt;
             for (const auto &binding : result.second.get_child("")) {
                 auto name = util::XmlReader::readAttribute("<xmlattr>.name", binding.second);
-                if (name == "nodeGeo") {
+                if (name == "val") {
                     auto uri = binding.second.get<std::string>("uri");
                     id = OsmObjectHelper::getIdFromUri(uri);
                 }
@@ -217,7 +217,7 @@ namespace olu::osm {
             std::string memberPositions;
             for (const auto &binding : result.second.get_child("")) {
                 auto name = util::XmlReader::readAttribute("<xmlattr>.name",binding.second);
-                if (name == "rel") {
+                if (name == "val") {
                     auto relUri = binding.second.get<std::string>("uri");
                     relationId = OsmObjectHelper::getIdFromUri(relUri);
                 }
@@ -290,7 +290,7 @@ namespace olu::osm {
             std::string nodePositions;
             for (const auto &binding : result.second.get_child("")) {
                 auto name = util::XmlReader::readAttribute("<xmlattr>.name",binding.second);
-                if (name == "way") {
+                if (name == "val") {
                     auto wayUri = binding.second.get<std::string>("uri");
                     wayId = OsmObjectHelper::getIdFromUri(wayUri);
                 }

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -69,7 +69,7 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
 std::string
 olu::sparql::QueryWriter::writeQueryForNodeLocations(const std::set<id_t> &nodeIds) const {
     std::ostringstream oss;
-    oss << "SELECT ?nodeGeo ?location ";
+    oss << "SELECT ?val ?location ";
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osm2rdfgeom:osm_node_", nodeIds);

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -57,8 +57,8 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
     oss << "DELETE { ";
     oss << wrapWithGraphOptional("?val ?p1 ?o1 . ?o1 ?pred ?o2 . ");
     oss << "} WHERE { ";
-    oss << getValuesClause(osmTag + ":", ids);
     oss << wrapWithGraphOptional(
+        getValuesClause(osmTag + ":", ids) +
         "?val ?p1 ?o1 FILTER (! STRSTARTS(?p1, ogc:)) . "
         "OPTIONAL {" + optionalPredicates + " ?o1 ?pred ?o2. }");
     oss << " }";


### PR DESCRIPTION
New option 'no-blank-nodes' to use a unique identifier instead of blank nodes. See [this](https://github.com/ad-freiburg/osm2rdf/pull/114) pull request for osm2rdf 