### PR TITLE
Reduce number of updated triples

### DIFF
--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -78,6 +78,35 @@ namespace olu::config::constants {
     const static inline std::string OSM_GEOM_NODE_URI = "https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_";
     const static inline std::string OSM_TAG_KEY = "https://www.openstreetmap.org/wiki/Key:";
 
+    // osm2rdf predicates
+    const static inline std::string OSM_2_RDF_WAY_MEMBER = "osmway:member";
+    const static inline std::string OSM_2_RDF_WAY_MEMBER_ID = "osmway:member_id";
+    const static inline std::string OSM_2_RDF_WAY_MEMBER_POS = "osmway:member_pos";
+
+    const static inline std::string OSM_2_RDF_RELATION_MEMBER = "osmrel:member";
+    const static inline std::string OSM_2_RDF_RELATION_MEMBER_ID = "osmrel:member_id";
+    const static inline std::string OSM_2_RDF_RELATION_MEMBER_POS = "osmrel:member_pos";
+    const static inline std::string OSM_2_RDF_RELATION_MEMBER_ROLE = "osmrel:member_role";
+
+    const static inline std::string OSM_2_RDF_GEO_HAS_GEOMETRY = "geo:hasGeometry";
+    const static inline std::string OSM_2_RDF_GEO_HAS_CENTROID = "geo:hasCentroid";
+    const static inline std::string OSM_2_RDF_GEO_AS_WKT = "geo:asWKT";
+
+    // variable names in query writer class
+    const static inline std::string QUERY_VARIABLE_TYPE = "type";
+    const static inline std::string QUERY_VARIABLE_KEY = "key";
+    const static inline std::string QUERY_VARIABLE_VALUE = "value";
+    const static inline std::string QUERY_VARIABLE_LOCATION = "location";
+    const static inline std::string QUERY_VARIABLE_TIMESTAMP = "timestamp";
+    const static inline std::string QUERY_VARIABLE_VERSION = "version";
+    const static inline std::string QUERY_VARIABLE_CHANGESET = "changeset";
+
+    const static inline std::string QUERY_VARIABLE_NODES = "nodes";
+
+    const static inline std::string QUERY_VARIABLE_MEMBER_URIS = "memberUris";
+    const static inline std::string QUERY_VARIABLE_MEMBER_ROLES = "memberRoles";
+    const static inline std::string QUERY_VARIABLE_MEMBER_POSITIONS = "memberPositions";
+
     const static inline std::vector<std::string> DEFAULT_PREFIXES{
         "PREFIX ohmnode: <https://www.openhistoricalmap.org/node/>"
         "PREFIX osmrel: <https://www.openstreetmap.org/relation/>"
@@ -121,14 +150,16 @@ namespace olu::config::constants {
             "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>"
     };
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_TAGS{
+    const static inline std::vector<std::string> PREFIXES_FOR_WAY_TAGS_AND_META_INFO{
             "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>"
+            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
+            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
     };
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_TAGS{
+    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_TAGS_AND_META_INFO{
             "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>"
+            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
+            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
     };
 
     const static inline std::vector<std::string> PREFIXES_FOR_LATEST_NODE_TIMESTAMP {

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -70,6 +70,8 @@ namespace olu::config::constants {
 
     const static inline std::string NODE_REFERENCE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "ref";
     const static inline std::string ID_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "id";
+    const static inline std::string LATITUDE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "lat";
+    const static inline std::string LONGITUDE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "lon";
 
     // SPARQL
     const static inline std::string OSM_WAY_URI = "https://www.openstreetmap.org/way/";

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -58,6 +58,8 @@ namespace olu::osm {
         std::set<id_t> _createdNodes;
         // Nodes that are in a modify-changeset in the change file.
         std::set<id_t> _modifiedNodes;
+        // Nodes that where modified in the changeset and have a location that has changed.
+        std::set<id_t> _modifiedNodesWithChangedLocation;
         // Nodes that are referenced by a way or relation that are NOT present in the change file,
         // meaning they have to be fetched from the database
         std::set<id_t> _referencedNodes;
@@ -135,6 +137,17 @@ namespace olu::osm {
          * corresponding set (_createdNodes, _modifiedNodes, _deletedNodes, etc.).
          */
         void storeIdsOfElementsInChangeFile();
+
+        /**
+         * Checks if the location of the given nodes from the change file has changed. If so, the
+         * node is added to the _modifiedNodesWithChangedLocation set, otherwise to the
+         * _modifiedNodes set
+         *
+         * @param nodeIds The ids of the nodes to check
+         * @param nodeLocs The locations of the nodes to check
+         */
+        void checkNodesForLocationChange(std::set<id_t> &nodeIds,
+                                         const std::vector<osmium::Location> & nodeLocs);
 
         /**
          * Stores the ids of the nodes and ways that are referenced in the given relation or way in
@@ -258,6 +271,14 @@ namespace olu::osm {
          * @return The id of the element
          */
         static id_t getIdFor(const boost::property_tree::ptree &element);
+
+        /**
+         * Returns the elements location.
+         *
+         * @param element The osm element
+         * @return The location of the element
+         */
+        static osmium::Location getLocationFor(const boost::property_tree::ptree &element);
     };
 
     /**

--- a/include/osm/OsmDataFetcher.h
+++ b/include/osm/OsmDataFetcher.h
@@ -92,6 +92,17 @@ namespace olu::osm {
         std::vector<Node> fetchNodes(const std::set<id_t> &nodeIds);
 
         /**
+         * Sends a query to the sparql endpoint to get the location of the nodes with the given ids
+         *
+         * @warning It is not guaranteed that the SPARQL endpoint returns a location for each node
+         * ID, therefore the returned vector can have fewer elements than the given set of node ids
+         *
+         * @param nodeIds The ids of the nodes to fetch location for
+         * @return A vector containing the locations
+         */
+        std::vector<osmium::Location> fetchNodeLocations(const std::vector<id_t> &nodeIds);
+
+        /**
          * @return A vector containing a pair of the member's uri and role for all members of the
          * given relation.
          */

--- a/include/osm/Relation.h
+++ b/include/osm/Relation.h
@@ -43,6 +43,8 @@ namespace olu::osm {
 
         void setType(std::string const& type);
         void setTimestamp(std::string const& timestamp);
+        void setVersion(version_t const& version);
+        void setChangesetId(changeset_id_t const& changeset_id);
 
         void addMember(const RelationMember& member);
         void addTag(const std::string& key, const std::string& value);
@@ -66,9 +68,13 @@ namespace olu::osm {
         [[nodiscard]] id_t getId() const { return id; }
         std::vector<KeyValue> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
+        [[nodiscard]] version_t getVersion() const { return version; }
+        [[nodiscard]] changeset_id_t getChangesetId() const { return changeset_id; }
     protected:
         id_t id;
         std::string timestamp;
+        version_t version = 0;
+        changeset_id_t changeset_id = 0;
         std::string type;
         std::vector<RelationMember> members;
         std::vector<KeyValue> tags;

--- a/include/osm/Way.h
+++ b/include/osm/Way.h
@@ -31,6 +31,8 @@ namespace olu::osm {
         explicit Way(const id_t id): id(id) {};
 
         void setTimestamp(std::string const& timestamp);
+        void setVersion(version_t const& version);
+        void setChangesetId(changeset_id_t const& changeset_id);
 
         void addMember(id_t nodeId);
         void addTag(const std::string& key, const std::string& value);
@@ -47,9 +49,13 @@ namespace olu::osm {
         [[nodiscard]] id_t getId() const { return id; }
         std::vector<KeyValue> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
+        [[nodiscard]] version_t getVersion() const { return version; }
+        [[nodiscard]] changeset_id_t getChangesetId() const { return changeset_id; }
     protected:
         id_t id;
         std::string timestamp;
+        version_t version = 0;
+        changeset_id_t changeset_id = 0;
         std::vector<id_t> members;
         std::vector<KeyValue> tags;
     };

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -99,7 +99,7 @@ namespace olu::sparql {
         /**
         * @returns A SPARQL query for tags and timestamp of the given subject
         */
-        [[nodiscard]] std::string writeQueryForTagsAndTimestamp(const std::string &subject) const;
+        [[nodiscard]] std::string writeQueryForTagsAndMetaInfo(const std::string &subject) const;
 
         private:
         config::Config _config;
@@ -107,14 +107,19 @@ namespace olu::sparql {
         [[nodiscard]] std::string getFromClauseOptional() const;
 
         [[nodiscard]] static std::string getValuesClause(const std::string& osmTag,
-                                                         const std::set<id_t> &objectIds) ;
+                                                         const std::set<id_t> &objectIds);
+
+        [[nodiscard]] static std::string getTripleClause(const std::string& subject,
+                                                         const std::string& predicate,
+                                                         const std::string& object);
 
         [[nodiscard]] std::string wrapWithGraphOptional(const std::string& clause) const;
+        [[nodiscard]] static std::string wrapWithUnion(const std::string& clause) ;
     };
 
     /**
- * Exception that can appear inside the `QueryWriter` class.
- */
+    * Exception that can appear inside the `QueryWriter` class.
+    */
     class QueryWriterException final : public std::exception {
         std::string message;
 

--- a/include/util/Types.h
+++ b/include/util/Types.h
@@ -26,6 +26,8 @@
 namespace olu {
 
     typedef int64_t id_t;
+    typedef uint32_t changeset_id_t;
+    typedef uint32_t version_t;
 
     typedef std::string WKTPoint;
 

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -59,10 +59,6 @@ namespace olu::osm {
                                                                        _queryWriter(config),
                                                                        _odf(config) {
         try {
-            std::cout
-            << osm2rdf::util::currentTimeFormatted()
-            << "Process change file..."
-            << std::endl;
             const auto decompressed = util::Decompressor::readGzip(cnst::PATH_TO_CHANGE_FILE);
             util::XmlReader::populatePTreeFromString(decompressed, _osmChangeElement);
             _osmChangeElement = _osmChangeElement.get_child(cnst::OSM_CHANGE_TAG);
@@ -122,7 +118,7 @@ namespace olu::osm {
             << _createdRelations.size() << " modified: " << _modifiedRelations.size()
             << " deleted: " << _deletedRelations.size() << std::endl;
         std::cout << osm2rdf::util::currentTimeFormatted() << "updated geometries for "
-            << _waysToUpdateGeometry.size() << " ways " << _relationsToUpdateGeometry.size()
+            << _waysToUpdateGeometry.size() << " ways and " << _relationsToUpdateGeometry.size()
             << " relations" << std::endl;
     }
 

--- a/src/osm/OsmUpdater.cpp
+++ b/src/osm/OsmUpdater.cpp
@@ -93,9 +93,9 @@ namespace olu::osm {
 
             std::cout
             << osm2rdf::util::currentTimeFormatted()
-            << "Process changes in "
+            << "Process changes from "
             << _latestState.sequenceNumber - sequenceNumber + 1
-            << " change files"
+            << " change files..."
             << std::endl;
 
             auto och{OsmChangeHandler(_config)};

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -16,6 +16,14 @@ namespace olu::osm {
         this->timestamp = timestamp;
     }
 
+    void Relation::setVersion(version_t const &version) {
+        this->version = version;
+    }
+
+    void Relation::setChangesetId(changeset_id_t const &changeset_id) {
+        this->changeset_id = changeset_id;
+    }
+
     void Relation::addMember(const RelationMember& member) {
         this->members.push_back(member);
     }
@@ -30,6 +38,18 @@ namespace olu::osm {
         oss << "<relation id=\"";
         oss << std::to_string(this->id);
         oss << "\"";
+
+        if (this->version > 0) {
+            oss << " version=\"";
+            oss << this->version;
+            oss << "\"";
+        }
+
+        if (this->changeset_id > 0) {
+            oss << " changeset=\"";
+            oss << this->changeset_id;
+            oss << "\"";
+        }
 
         if (!this->timestamp.empty()) {
             oss << " timestamp=\"";

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -26,6 +26,14 @@ namespace olu::osm {
         this->timestamp = timestamp;
     }
 
+    void Way::setVersion(version_t const &version) {
+        this->version = version;
+    }
+
+    void Way::setChangesetId(changeset_id_t const &changeset_id) {
+        this->changeset_id = changeset_id;
+    }
+
     void Way::addMember(id_t nodeId) {
         members.emplace_back(nodeId);
     }
@@ -40,6 +48,18 @@ namespace olu::osm {
         oss << "<way id=\"";
         oss << std::to_string(this->getId());
         oss << "\"";
+
+        if (this->version > 0) {
+            oss << " version=\"";
+            oss << this->version;
+            oss << "\"";
+        }
+
+        if (this->changeset_id > 0) {
+            oss << " changeset=\"";
+            oss << this->changeset_id;
+            oss << "\"";
+        }
 
         if (!this->timestamp.empty()) {
             oss << " timestamp=\"";

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -17,10 +17,13 @@
 // along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "sparql/QueryWriter.h"
+#include "config/Constants.h"
 
 #include <string>
 #include <vector>
 #include <sstream>
+
+namespace cnst = olu::config::constants;
 
 // _________________________________________________________________________________________________
 std::string olu::sparql::QueryWriter::writeInsertQuery(const std::vector<std::string>& triples) const {
@@ -43,11 +46,11 @@ std::string
 olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std::string &osmTag) const {
     std::string optionalPredicates;
     if (osmTag == "osmnode") {
-        optionalPredicates = "VALUES ?pred { geo:asWKT }";
+        optionalPredicates = "VALUES ?pred { "+ cnst::OSM_2_RDF_GEO_AS_WKT +" }";
     } else if (osmTag == "osmway") {
-        optionalPredicates = "VALUES ?pred { osmway:member_id osmway:member_pos geo:asWKT }";
+        optionalPredicates = "VALUES ?pred { " + cnst::OSM_2_RDF_WAY_MEMBER_ID + " " + cnst::OSM_2_RDF_WAY_MEMBER_POS + " " + cnst::OSM_2_RDF_GEO_AS_WKT + " }";
     } else if (osmTag == "osmrel") {
-        optionalPredicates = "VALUES ?pred { osmrel:member_id osmrel:member_role osmrel:member_pos geo:asWKT }";
+        optionalPredicates = "VALUES ?pred { " + cnst::OSM_2_RDF_RELATION_MEMBER_ID + " " + cnst::OSM_2_RDF_RELATION_MEMBER_POS + " " + cnst::OSM_2_RDF_RELATION_MEMBER_ROLE + " " + cnst::OSM_2_RDF_GEO_AS_WKT + " }";
     } else {
         const std::string msg = "Unknown osmTag: " + osmTag;
         throw QueryWriterException(msg.c_str());
@@ -55,69 +58,76 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
 
     std::ostringstream oss;
     oss << "DELETE { ";
-    oss << wrapWithGraphOptional("?val ?p1 ?o1 . ?o1 ?pred ?o2 . ");
+    oss << wrapWithGraphOptional(
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "?p1", "?o1") +
+        getTripleClause("?o1", "?pred", "?o2"));
     oss << "} WHERE { ";
     oss << wrapWithGraphOptional(
         getValuesClause(osmTag + ":", ids) +
-        "?val ?p1 ?o1 FILTER (! STRSTARTS(STR(?p1), STR(ogc:))) . "
-        "OPTIONAL {" + optionalPredicates + " ?o1 ?pred ?o2. }");
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "?p1", "?o1") +
+        "FILTER (! STRSTARTS(STR(?p1), STR(ogc:))) . "
+        "OPTIONAL {" + optionalPredicates +
+        getTripleClause("?o1", "?pred", "?o2") + "}" );
     oss << " }";
     return oss.str();
 }
-
 // _________________________________________________________________________________________________
 std::string
 olu::sparql::QueryWriter::writeQueryForNodeLocations(const std::set<id_t> &nodeIds) const {
     std::ostringstream oss;
-    oss << "SELECT ?val ?location ";
+    oss << "SELECT ?" + cnst::QUERY_VARIABLE_VALUE + " ?" + cnst::QUERY_VARIABLE_LOCATION + " ";
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osm2rdfgeom:osm_node_", nodeIds);
-    oss << "?val geo:asWKT ?location . }";
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, cnst::OSM_2_RDF_GEO_AS_WKT, "?" + cnst::QUERY_VARIABLE_LOCATION);
+    oss << "}";
     return oss.str();
 }
 
 // _________________________________________________________________________________________________
 std::string olu::sparql::QueryWriter::writeQueryForLatestNodeTimestamp() const {
     std::ostringstream oss;
-    oss << "SELECT ?p ";
+    oss << "SELECT ?" + cnst::QUERY_VARIABLE_TIMESTAMP + " ";
     oss << getFromClauseOptional();
-    oss << "WHERE { ?s rdf:type osm:node . ?s osmmeta:timestamp ?p . } ORDER BY DESC(?p) LIMIT 1";
+    oss << "WHERE { ";
+    oss << getTripleClause("?node", "rdf:type", "osm:node");
+    oss << getTripleClause("?node", "osmmeta:timestamp", "?" + cnst::QUERY_VARIABLE_TIMESTAMP);
+    oss << "} ORDER BY DESC(?" + cnst::QUERY_VARIABLE_TIMESTAMP + ") LIMIT 1";
     return oss.str();
 }
 
 // _________________________________________________________________________________________________
 std::string olu::sparql::QueryWriter::writeQueryForRelations(const std::set<id_t> & relationIds) const {
     std::ostringstream oss;
-    oss << "SELECT ?val ?type"
-          "(GROUP_CONCAT(?memberUri; separator=\";\") AS ?memberUris) "
-          "(GROUP_CONCAT(?memberRole; separator=\";\") AS ?memberRoles) "
-          "(GROUP_CONCAT(?memberPos; separator=\";\") AS ?memberPositions) ";
+    oss << "SELECT ?" + cnst::QUERY_VARIABLE_VALUE + " ?" + cnst::QUERY_VARIABLE_TYPE + " "
+          "(GROUP_CONCAT(?memberUri; separator=\";\") AS ?" + cnst::QUERY_VARIABLE_MEMBER_URIS + ") "
+          "(GROUP_CONCAT(?memberRole; separator=\";\") AS ?" + cnst::QUERY_VARIABLE_MEMBER_ROLES + ") "
+          "(GROUP_CONCAT(?memberPos; separator=\";\") AS ?" + cnst::QUERY_VARIABLE_MEMBER_POSITIONS + ") ";
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmrel:", relationIds);
-    oss << "?val osmkey:type ?type . "
-          "?val osmrel:member ?o . "
-          "?o osm2rdfmember:id ?memberUri . "
-          "?o osm2rdfmember:role ?memberRole . "
-          "?o osm2rdfmember:pos ?memberPos . "
-          "} GROUP BY ?val ?type";
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osmkey:type", "?type");
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, cnst::OSM_2_RDF_RELATION_MEMBER, "?member");
+    oss << getTripleClause("?member", cnst::OSM_2_RDF_RELATION_MEMBER_ID, "?memberUri");
+    oss << getTripleClause("?member", cnst::OSM_2_RDF_RELATION_MEMBER_ROLE, "?memberRole");
+    oss << getTripleClause("?member", cnst::OSM_2_RDF_RELATION_MEMBER_POS, "?memberPos");
+    oss << "} GROUP BY ?" + cnst::QUERY_VARIABLE_VALUE + " ?" + cnst::QUERY_VARIABLE_TYPE;
     return oss.str();
 }
 
 // _________________________________________________________________________________________________
 std::string olu::sparql::QueryWriter::writeQueryForWaysMembers(const std::set<id_t> &wayIds) const {
     std::ostringstream oss;
-    oss << "SELECT ?val "
-          "(GROUP_CONCAT(?nodeUri; separator=\";\") AS ?nodeUris) "
-          "(GROUP_CONCAT(?nodePos; separator=\";\") AS ?nodePositions) ";
+    oss << "SELECT ?" + cnst::QUERY_VARIABLE_VALUE + " "
+          "(GROUP_CONCAT(?nodeUri; separator=\";\") AS ?" + cnst::QUERY_VARIABLE_MEMBER_URIS + ") "
+          "(GROUP_CONCAT(?nodePos; separator=\";\") AS ?" + cnst::QUERY_VARIABLE_MEMBER_POSITIONS + ") ";
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmway:", wayIds);
-    oss << "?val osmway:node ?member . "
-          "?member osmway:node ?nodeUri . "
-          "?member osm2rdfmember:pos ?nodePos "
-          "} GROUP BY ?val";
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, cnst::OSM_2_RDF_WAY_MEMBER, "?node");
+    oss << getTripleClause("?node", cnst::OSM_2_RDF_WAY_MEMBER_ID, "?nodeUri");
+    oss << getTripleClause("?node", cnst::OSM_2_RDF_WAY_MEMBER_POS, "?nodePos");
+    oss << "} GROUP BY ?" + cnst::QUERY_VARIABLE_VALUE;
     return oss.str();
 }
 
@@ -128,7 +138,9 @@ std::string olu::sparql::QueryWriter::writeQueryForReferencedNodes(const std::se
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmway:", wayIds);
-    oss << "?val osmway:node ?member . ?member osmway:node ?node . } GROUP BY ?node";
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, cnst::OSM_2_RDF_WAY_MEMBER, "?member");
+    oss << getTripleClause("?member", cnst::OSM_2_RDF_WAY_MEMBER_ID, "?node");
+    oss << "} GROUP BY ?node";
     return oss.str();
 }
 
@@ -139,7 +151,9 @@ std::string olu::sparql::QueryWriter::writeQueryForRelationMembers(const std::se
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmrel:", relIds);
-    oss << "?val osmrel:member ?o . ?o osm2rdfmember:id ?p . } GROUP BY ?p";
+    oss << getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, cnst::OSM_2_RDF_RELATION_MEMBER, "?o");
+    oss << getTripleClause("?o", cnst::OSM_2_RDF_RELATION_MEMBER_ID, "?p");
+    oss << "} GROUP BY ?p";
     return oss.str();
 }
 
@@ -151,7 +165,9 @@ olu::sparql::QueryWriter::writeQueryForWaysReferencingNodes(const std::set<id_t>
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmnode:", nodeIds);
-    oss << "?identifier osmway:node ?val . ?way osmway:node ?identifier . } GROUP BY ?way";
+    oss << getTripleClause("?s", cnst::OSM_2_RDF_WAY_MEMBER_ID, "?" + cnst::QUERY_VARIABLE_VALUE);
+    oss << getTripleClause("?way", cnst::OSM_2_RDF_WAY_MEMBER, "?s");
+    oss << "} GROUP BY ?way";
     return oss.str();
 }
 
@@ -163,7 +179,9 @@ olu::sparql::QueryWriter::writeQueryForRelationsReferencingNodes(const std::set<
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmnode:", nodeIds);
-    oss << "?s osmrel:member ?o . ?o osm2rdfmember:id ?val . } GROUP BY ?s";
+    oss << getTripleClause("?s", cnst::OSM_2_RDF_RELATION_MEMBER, "?o");
+    oss << getTripleClause("?o", cnst::OSM_2_RDF_RELATION_MEMBER_ID, "?" + cnst::QUERY_VARIABLE_VALUE);
+    oss << "} GROUP BY ?s";
     return oss.str();
 }
 
@@ -175,7 +193,9 @@ olu::sparql::QueryWriter::writeQueryForRelationsReferencingWays(const std::set<i
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmway:", wayIds);
-    oss << "?s osmrel:member ?o . ?o osm2rdfmember:id ?val . } GROUP BY ?s";
+    oss << getTripleClause("?s", cnst::OSM_2_RDF_RELATION_MEMBER, "?o");
+    oss << getTripleClause("?o", cnst::OSM_2_RDF_RELATION_MEMBER_ID, "?" + cnst::QUERY_VARIABLE_VALUE);
+    oss << "} GROUP BY ?s";
     return oss.str();
 }
 
@@ -187,23 +207,29 @@ olu::sparql::QueryWriter::writeQueryForRelationsReferencingRelations(const std::
     oss << getFromClauseOptional();
     oss << "WHERE { ";
     oss << getValuesClause("osmrel:", relationIds);
-    oss << "?s osmrel:member ?o . "
-          "?o osm2rdfmember:id ?val . } "
-          "GROUP BY ?s";
+    oss << getTripleClause("?s", cnst::OSM_2_RDF_RELATION_MEMBER, "?o");
+    oss << getTripleClause("?o", cnst::OSM_2_RDF_RELATION_MEMBER_ID, "?" + cnst::QUERY_VARIABLE_VALUE);
+    oss << "} ";
+    oss << "GROUP BY ?s";
     return oss.str();
 }
 
-std::string olu::sparql::QueryWriter::writeQueryForTagsAndTimestamp(const std::string &subject) const {
+std::string olu::sparql::QueryWriter::writeQueryForTagsAndMetaInfo(const std::string &subject) const {
     std::ostringstream oss;
-    oss << "SELECT ?key ?value ?time ";
+    oss << "SELECT ";
+    oss << "?" + cnst::QUERY_VARIABLE_KEY + " ";
+    oss << "?" + cnst::QUERY_VARIABLE_VALUE + " ";
+    oss << "?" + cnst::QUERY_VARIABLE_TIMESTAMP + " ";
+    oss << "?" + cnst::QUERY_VARIABLE_VERSION + " ";
+    oss << "?" + cnst::QUERY_VARIABLE_CHANGESET + " ";
     oss << getFromClauseOptional();
     oss << "WHERE { { ";
-    oss << subject;
-    oss << " ?key ?value . "
-          "FILTER regex(str(?key), \"https://www.openstreetmap.org/wiki/Key:\") } "
-          "UNION { ";
-    oss << subject;
-    oss << " osmmeta:timestamp ?time } }";
+    oss << getTripleClause(subject, "?" + cnst::QUERY_VARIABLE_KEY, "?" + cnst::QUERY_VARIABLE_VALUE);
+    oss << "FILTER REGEX(STR(?" + cnst::QUERY_VARIABLE_KEY + "), STR(osmkey:)) } ";
+    oss << wrapWithUnion(getTripleClause(subject, "osmmeta:timestamp", "?" + cnst::QUERY_VARIABLE_TIMESTAMP));
+    oss << wrapWithUnion(getTripleClause(subject, "osmmeta:version", "?" + cnst::QUERY_VARIABLE_VERSION));
+    oss << wrapWithUnion(getTripleClause(subject, "osmmeta:changeset", "?" + cnst::QUERY_VARIABLE_CHANGESET));
+    oss << " }";
 
     return oss.str();
 }
@@ -215,7 +241,7 @@ std::string olu::sparql::QueryWriter::getFromClauseOptional() const {
 std::string olu::sparql::QueryWriter::getValuesClause(const std::string &osmTag,
                                                       const std::set<id_t> &objectIds) {
     std::ostringstream oss;
-    oss << "VALUES ?val { ";
+    oss << "VALUES ?"+ cnst::QUERY_VARIABLE_VALUE +" { ";
     for (const auto & objectId : objectIds) {
         oss << osmTag;
         oss << std::to_string(objectId);
@@ -228,4 +254,14 @@ std::string olu::sparql::QueryWriter::getValuesClause(const std::string &osmTag,
 
 std::string olu::sparql::QueryWriter::wrapWithGraphOptional(const std::string& clause) const {
     return _config.graphUri.empty() ? clause : "GRAPH <" + _config.graphUri + "> { " + clause + " } ";
+}
+
+std::string olu::sparql::QueryWriter::wrapWithUnion(const std::string& clause) {
+    return "UNION { " + clause + " } ";
+}
+
+std::string olu::sparql::QueryWriter::getTripleClause(const std::string& subject,
+                                                      const std::string& predicate,
+                                                      const std::string& object) {
+    return subject + " " + predicate + " " + object + " . ";
 }

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -59,7 +59,7 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
     oss << "} WHERE { ";
     oss << wrapWithGraphOptional(
         getValuesClause(osmTag + ":", ids) +
-        "?val ?p1 ?o1 FILTER (! STRSTARTS(?p1, ogc:)) . "
+        "?val ?p1 ?o1 FILTER (! STRSTARTS(STR(?p1), STR(ogc:))) . "
         "OPTIONAL {" + optionalPredicates + " ?o1 ?pred ?o2. }");
     oss << " }";
     return oss.str();

--- a/src/util/TtlHelper.cpp
+++ b/src/util/TtlHelper.cpp
@@ -39,20 +39,20 @@ namespace olu::util {
 
     bool TtlHelper::hasRelevantObject(const std::string& predicate, const std::string &osmTag) {
         if (osmTag == cnst::NODE_TAG) {
-            return predicate == "geo:hasCentroid" ||
-                   predicate == "geo:hasGeometry";
+            return predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
+                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
         }
 
         if (osmTag == cnst::WAY_TAG) {
-            return predicate == "osmway:member" ||
-                   predicate == "geo:hasCentroid" ||
-                   predicate == "geo:hasGeometry";
+            return predicate == cnst::OSM_2_RDF_WAY_MEMBER ||
+                   predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
+                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
         }
 
         if (osmTag == cnst::RELATION_TAG) {
-            return predicate == "osmrel:member" ||
-                   predicate == "geo:hasCentroid" ||
-                   predicate == "geo:hasGeometry";
+            return predicate == cnst::OSM_2_RDF_RELATION_MEMBER ||
+                   predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
+                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
         }
 
         const std::string msg = "Cant interpret predicate: " + predicate;


### PR DESCRIPTION
- Check if nodes that occur as modified in the change file have changed their location, to avoid updating the geometries for ways and relations that reference a node whose location hasn't changed.
- Fixed remaining issues with osm2rdf changes