### PR TITLE
Reduce number of updated triples II

### DIFF
--- a/benchmarks/util/XmlReader.cpp
+++ b/benchmarks/util/XmlReader.cpp
@@ -81,7 +81,7 @@ static void Read_Tag_Of_Children(benchmark::State& state) {
 
     for (auto _ : state) {
         auto childrenTags = olu::util::XmlReader::readTagOfChildren(
-                olu::config::constants::OSM_TAG,
+                olu::config::constants::XML_TAG_OSM,
                 tree,
                 false);
     }

--- a/benchmarks/util/XmlReader.cpp
+++ b/benchmarks/util/XmlReader.cpp
@@ -34,7 +34,7 @@ static void Read_Attribute(benchmark::State& state) {
     olu::util::XmlReader::populatePTreeFromString(content, tree);
 
     for (auto _ : state) {
-        std::string attribute = olu::util::XmlReader::readAttribute(
+        auto attribute = olu::util::XmlReader::readAttribute<std::string>(
                 "osm.node.id",
                 tree);
     }

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -21,14 +21,13 @@
 
 #include <string>
 #include <vector>
+#include <sstream>
 
 namespace olu::config::constants {
+    // Exception Messages --------------------------------------------------------------------------
+    const static inline auto EXCEPTION_MSG_SEQUENCE_NUMBER_IS_INVALID = "Sequence number is invalid.";
 
-    // Exception Messages
-    const static inline char *const EXCEPTION_MSG_SEQUENCE_NUMBER_IS_INVALID =
-        "Sequence number is invalid.";
-
-    // HTML
+    // HTML ----------------------------------------------------------------------------------------
     const static inline std::string HTML_KEY_CONTENT_TYPE = "Content-Type";
     const static inline std::string HTML_VALUE_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
@@ -38,204 +37,293 @@ namespace olu::config::constants {
     const static inline std::string HTML_VALUE_ACCEPT_SPARQL_RESULT_JSON =
             "application/sparql-results+json";
 
-    // File extensions
+    // File extensions -----------------------------------------------------------------------------
     const static inline std::string OSM_CHANGE_FILE_EXTENSION = ".osc";
     const static inline std::string GZIP_EXTENSION = ".gz";
+    const static inline std::string OSM_EXTENSION = ".osm";
+    const static inline std::string TURTLE_FILE_EXTENSION = ".ttl";
+    const static inline std::string TEXT_FILE_EXTENSION = ".txt";
 
-    // File names
+    // Directory paths -----------------------------------------------------------------------------
     const static inline std::string PATH_TO_TEMP_DIR = "tmp/";
     const static inline std::string PATH_TO_CHANGE_FILE_DIR = PATH_TO_TEMP_DIR + "changes/";
-    const static inline std::string CHANGE_FILE_NAME = "changes.osc.gz";
-    const static inline std::string PATH_TO_CHANGE_FILE = PATH_TO_TEMP_DIR + CHANGE_FILE_NAME;
-    const static inline std::string PATH_TO_NODE_FILE = PATH_TO_TEMP_DIR + "nodes.osm";
-    const static inline std::string PATH_TO_WAY_FILE = PATH_TO_TEMP_DIR + "ways.osm";
-    const static inline std::string PATH_TO_RELATION_FILE = PATH_TO_TEMP_DIR + "relations.osm";
-
-    // Osm2rdf
-    const static inline std::string PATH_TO_INPUT_FILE = PATH_TO_TEMP_DIR + "input.osm";
-    const static inline std::string PATH_TO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "output.ttl";
     const static inline std::string PATH_TO_SCRATCH_DIRECTORY = "osm2rdfScratch/";
 
-    // OsmChangeHandler
-    const static inline std::string XML_ATTRIBUTE_TAG = "<xmlattr>";
-    const static inline std::string NODE_TAG = "node";
-    const static inline std::string NODE_REFERENCE_TAG = "nd";
-    const static inline std::string WAY_TAG = "way";
-    const static inline std::string RELATION_TAG = "relation";
-    const static inline std::string OSM_TAG = "osm";
-    const static inline std::string OSM_CHANGE_TAG = "osmChange";
+    // File paths ----------------------------------------------------------------------------------
+    const static inline std::string PATH_TO_CHANGE_FILE = PATH_TO_TEMP_DIR + "changes" + OSM_CHANGE_FILE_EXTENSION + GZIP_EXTENSION;
+    const static inline std::string PATH_TO_NODE_FILE = PATH_TO_TEMP_DIR + "nodes" + OSM_EXTENSION;
+    const static inline std::string PATH_TO_WAY_FILE = PATH_TO_TEMP_DIR + "ways" + OSM_EXTENSION;
+    const static inline std::string PATH_TO_RELATION_FILE = PATH_TO_TEMP_DIR + "relations" + OSM_EXTENSION;
+    const static inline std::string PATH_TO_INPUT_FILE = PATH_TO_TEMP_DIR + "input" + OSM_EXTENSION;
+    const static inline std::string PATH_TO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "output" + TURTLE_FILE_EXTENSION;
+    const static inline std::string PATH_TO_OSM2RDF_INFO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "osm2rdf_info" + TEXT_FILE_EXTENSION;
+    const static inline std::string PATH_TO_STATE_FILE = "state" + TEXT_FILE_EXTENSION;
 
-    const static inline std::string MODIFY_TAG = "modify";
-    const static inline std::string DELETE_TAG = "delete";
-    const static inline std::string CREATE_TAG = "create";
+    // XML -----------------------------------------------------------------------------------------
+    const static inline std::string XML_TAG_ATTR = "<xmlattr>";
+    const static inline std::string XML_TAG_NODE = "node";
+    const static inline std::string XML_TAG_NODE_REF = "nd";
+    const static inline std::string XML_TAG_WAY = "way";
+    const static inline std::string XML_TAG_REL = "relation";
+    const static inline std::string XML_TAG_OSM = "osm";
+    const static inline std::string XML_TAG_OSM_CHANGE = "osmChange";
+    const static inline std::string XML_TAG_REF = "ref";
+    const static inline std::string XML_TAG_MEMBER = "member";
+    const static inline std::string XML_TAG_TYPE = "type";
+    const static inline std::string XML_TAG_ID = "id";
+    const static inline std::string XML_TAG_LAT = "lat";
+    const static inline std::string XML_TAG_LON = "lon";
+    const static inline std::string XML_TAG_MODIFY = "modify";
+    const static inline std::string XML_TAG_DELETE = "delete";
+    const static inline std::string XML_TAG_CREATE = "create";
+    const static inline std::string XML_TAG_SPARQL = "sparql";
+    const static inline std::string XML_TAG_RESULTS = "results";
+    const static inline std::string XML_TAG_NAME = "name";
+    const static inline std::string XML_TAG_URI = "uri";
+    const static inline std::string XML_TAG_LITERAL = "literal";
+    const static inline std::string XML_TAG_BINDING = "binding";
+    const static inline std::string XML_TAG_KEY = "k";
+    const static inline std::string XML_TAG_VALUE = "v";
+    const static inline std::string XML_TAG_TAG = "tag";
 
-    const static inline std::string NODE_REFERENCE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "ref";
-    const static inline std::string ID_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "id";
-    const static inline std::string LATITUDE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "lat";
-    const static inline std::string LONGITUDE_ATTRIBUTE = XML_ATTRIBUTE_TAG + "." + "lon";
+    static std::string MakeXMLPath(const std::vector<std::string> &segments) {
+        if (segments.empty()) {
+            return {};
+        }
 
-    // SPARQL
-    const static inline std::string OSM_WAY_URI = "https://www.openstreetmap.org/way/";
-    const static inline std::string OSM_NODE_URI = "https://www.openstreetmap.org/node/";
-    const static inline std::string OSM_REL_URI = "https://www.openstreetmap.org/relation/";
-    const static inline std::string OSM_GEOM_NODE_URI = "https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_";
-    const static inline std::string OSM_TAG_KEY = "https://www.openstreetmap.org/wiki/Key:";
+        std::ostringstream oss;
+        auto it = segments.begin();
+        oss << *it++;
 
-    // osm2rdf predicates
-    const static inline std::string OSM_NODE_PREFIX = "osmnode";
-    const static inline std::string OSM_WAY_PREFIX = "osmway";
-    const static inline std::string OSM_RELATION_PREFIX = "osmrel";
+        for (; it != segments.end(); ++it) {
+            oss << '.' << *it;
+        }
 
-    const static inline std::string OSM_2_RDF_WAY_MEMBER = "osmway:member";
-    const static inline std::string OSM_2_RDF_WAY_MEMBER_ID = "osmway:member_id";
-    const static inline std::string OSM_2_RDF_WAY_MEMBER_POS = "osmway:member_pos";
+        return oss.str();
+    }
+    const static inline std::string XML_PATH_ATTR_NODE_REF = MakeXMLPath({XML_TAG_ATTR, XML_TAG_REF});
+    const static inline std::string XML_PATH_ATTR_ID = MakeXMLPath({XML_TAG_ATTR, XML_TAG_ID});
+    const static inline std::string XML_PATH_ATTR_LAT = MakeXMLPath({XML_TAG_ATTR, XML_TAG_LAT});
+    const static inline std::string XML_PATH_ATTR_LON = MakeXMLPath({XML_TAG_ATTR, XML_TAG_LON});
+    const static inline std::string XML_PATH_ATTR_TYPE = MakeXMLPath({XML_TAG_ATTR, XML_TAG_TYPE});
+    const static inline std::string XML_PATH_ATTR_KEY = MakeXMLPath({XML_TAG_ATTR, XML_TAG_KEY});
+    const static inline std::string XML_PATH_ATTR_VALUE = MakeXMLPath({XML_TAG_ATTR, XML_TAG_VALUE});
+    const static inline std::string XML_PATH_ATTR_NAME = MakeXMLPath({XML_TAG_ATTR, XML_TAG_NAME});
+    const static inline std::string XML_PATH_SPARQL_RESULTS = MakeXMLPath({XML_TAG_SPARQL, XML_TAG_RESULTS});
+    const static inline std::string XML_PATH_BINDING_URI = MakeXMLPath({XML_TAG_BINDING, XML_TAG_URI});
 
-    const static inline std::string OSM_2_RDF_RELATION_MEMBER = "osmrel:member";
-    const static inline std::string OSM_2_RDF_RELATION_MEMBER_ID = "osmrel:member_id";
-    const static inline std::string OSM_2_RDF_RELATION_MEMBER_POS = "osmrel:member_pos";
-    const static inline std::string OSM_2_RDF_RELATION_MEMBER_ROLE = "osmrel:member_role";
+    // OSM2RDF -------------------------------------------------------------------------------------
+    /// Namespaces and prefixes --------------------------------------------------------------------
+    static std::string MakePrefixDecl(const std::string &prefix, const std::string &iri) {
+            return "PREFIX " + prefix + ": <" + iri + ">";
+    }
 
-    const static inline std::string OSM_2_RDF_GEO_HAS_GEOMETRY = "geo:hasGeometry";
-    const static inline std::string OSM_2_RDF_GEO_HAS_CENTROID = "geo:hasCentroid";
-    const static inline std::string OSM_2_RDF_GEO_AS_WKT = "geo:asWKT";
+    const static inline std::string NAMESPACE_OSM = "osm";
+    const static inline std::string NAMESPACE_IRI_OSM = "https://www.openstreetmap.org/";
+    const static inline std::string PREFIX_DECL_OSM = MakePrefixDecl(NAMESPACE_OSM, NAMESPACE_IRI_OSM);
 
-    // variable names in query writer class
-    const static inline std::string QUERY_VARIABLE_TYPE = "type";
-    const static inline std::string QUERY_VARIABLE_KEY = "key";
-    const static inline std::string QUERY_VARIABLE_VALUE = "value";
-    const static inline std::string QUERY_VARIABLE_LOCATION = "location";
-    const static inline std::string QUERY_VARIABLE_TIMESTAMP = "timestamp";
-    const static inline std::string QUERY_VARIABLE_VERSION = "version";
-    const static inline std::string QUERY_VARIABLE_CHANGESET = "changeset";
+    const static inline std::string NAMESPACE_OSM_NODE = "osmnode";
+    const static inline std::string NAMESPACE_IRI_OSM_NODE = "https://www.openstreetmap.org/node/";
+    const static inline std::string PREFIX_DECL_OSM_NODE = MakePrefixDecl(NAMESPACE_OSM_NODE, NAMESPACE_IRI_OSM_NODE);
 
-    const static inline std::string QUERY_VARIABLE_NODES = "nodes";
+    const static inline std::string NAMESPACE_OSM_WAY = "osmway";
+    const static inline std::string NAMESPACE_IRI_OSM_WAY = "https://www.openstreetmap.org/way/";
+    const static inline std::string PREFIX_DECL_OSM_WAY = MakePrefixDecl(NAMESPACE_OSM_WAY, NAMESPACE_IRI_OSM_WAY);
 
-    const static inline std::string QUERY_VARIABLE_MEMBER_URIS = "memberUris";
-    const static inline std::string QUERY_VARIABLE_MEMBER_ROLES = "memberRoles";
-    const static inline std::string QUERY_VARIABLE_MEMBER_POSITIONS = "memberPositions";
+    const static inline std::string NAMESPACE_OSM_REL = "osmrel";
+    const static inline std::string NAMESPACE_IRI_OSM_REL = "https://www.openstreetmap.org/relation/";
+    const static inline std::string PREFIX_DECL_OSM_REL = MakePrefixDecl(NAMESPACE_OSM_REL, NAMESPACE_IRI_OSM_REL);
 
-    const static inline std::vector<std::string> DEFAULT_PREFIXES{
-        "PREFIX ohmnode: <https://www.openhistoricalmap.org/node/>"
-        "PREFIX osmrel: <https://www.openstreetmap.org/relation/>"
-        "PREFIX osmnode: <https://www.openstreetmap.org/node/>"
-        "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
-        "PREFIX osmway: <https://www.openstreetmap.org/way/>"
-        "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>"
-        "PREFIX osm: <https://www.openstreetmap.org/>"
-        "PREFIX osm2rdfmeta: <https://osm2rdf.cs.uni-freiburg.de/rdf/meta#>"
-        "PREFIX ohmrel: <https://www.openhistoricalmap.org/relation/>"
-        "PREFIX osmt: <https://www.openstreetmap.org/wiki/Key:>"
-        "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>"
-        "PREFIX osm2rdfkey: <https://osm2rdf.cs.uni-freiburg.de/rdf/key#>"
-        "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
-        "PREFIX genid: <http://osm2rdf.cs.uni-freiburg.de/.well-known/genid/>"
-        "PREFIX ohmway: <https://www.openhistoricalmap.org/way/>"
-        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
-        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
-        "PREFIX ohm: <https://www.openhistoricalmap.org/>"
-        "PREFIX wd: <http://www.wikidata.org/entity/>"
-        "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>"
-        "PREFIX ogc: <http://www.opengis.net/rdf#>"
-        "PREFIX geo: <http://www.opengis.net/ont/geosparql#>"};
+    const static inline std::string NAMESPACE_OSM_KEY = "osmkey";
+    const static inline std::string NAMESPACE_IRI_OSM_KEY = "https://www.openstreetmap.org/wiki/Key:";
+    const static inline std::string PREFIX_DECL_OSM_KEY = MakePrefixDecl(NAMESPACE_OSM_KEY, NAMESPACE_IRI_OSM_KEY);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_NODE_LOCATION{
-            "PREFIX osmnode: <https://www.openstreetmap.org/node/>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
-            "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
-    };
+    const static inline std::string NAMESPACE_OSM_META = "osmmeta";
+    const static inline std::string NAMESPACE_IRI_OSM_META = "https://www.openstreetmap.org/meta/";
+    const static inline std::string PREFIX_DECL_OSM_META = MakePrefixDecl(NAMESPACE_OSM_META, NAMESPACE_IRI_OSM_META);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_MEMBERS{
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
-            "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>",
-            "PREFIX osm: <https://www.openstreetmap.org/>",
-            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF = "osm2rdf";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF = "https://osm2rdf.cs.uni-freiburg.de/rdf#";
+    const static inline std::string PREFIX_DECL_OSM2RDF = MakePrefixDecl(NAMESPACE_OSM2RDF, NAMESPACE_IRI_OSM2RDF);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_MEMBERS{
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF_META = "osm2rdfmeta";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF_META = "https://osm2rdf.cs.uni-freiburg.de/rdf/meta#";
+    const static inline std::string PREFIX_DECL_OSM2RDF_META = MakePrefixDecl(NAMESPACE_OSM2RDF_META, NAMESPACE_IRI_OSM2RDF_META);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_TAGS_AND_META_INFO{
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
-            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF_MEMBER = "osm2rdfmember";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF_MEMBER = "https://osm2rdf.cs.uni-freiburg.de/rdf/member#";
+    const static inline std::string PREFIX_DECL_OSM2RDF_MEMBER = MakePrefixDecl(NAMESPACE_OSM2RDF_MEMBER, NAMESPACE_IRI_OSM2RDF_MEMBER);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_TAGS_AND_META_INFO{
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
-            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF_KEY = "osm2rdfkey";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF_KEY = "https://osm2rdf.cs.uni-freiburg.de/rdf/key#";
+    const static inline std::string PREFIX_DECL_OSM2RDF_KEY = MakePrefixDecl(NAMESPACE_OSM2RDF_KEY, NAMESPACE_IRI_OSM2RDF_KEY);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_LATEST_NODE_TIMESTAMP {
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
-            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
-            "PREFIX osm: <https://www.openstreetmap.org/>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF_GEOM = "osm2rdfgeom";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF_GEOM = "https://osm2rdf.cs.uni-freiburg.de/rdf/geom#";
+    const static inline std::string PREFIX_DECL_OSM2RDF_GEOM = MakePrefixDecl(NAMESPACE_OSM2RDF_GEOM, NAMESPACE_IRI_OSM2RDF_GEOM);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_NODE_DELETE_QUERY {
-            "PREFIX osmnode: <https://www.openstreetmap.org/node/>",
-            "PREFIX ogc: <http://www.opengis.net/rdf#>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>"
-    };
+    const static inline std::string NAMESPACE_OSM2RDF_GENID = "genid";
+    const static inline std::string NAMESPACE_IRI_OSM2RDF_GENID = "http://osm2rdf.cs.uni-freiburg.de/.well-known/genid/";
+    const static inline std::string PREFIX_DECL_OSM2RDF_GENID = MakePrefixDecl(NAMESPACE_OSM2RDF_GENID, NAMESPACE_IRI_OSM2RDF_GENID);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_QUERY {
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX ogc: <http://www.opengis.net/rdf#>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>"
-    };
+    const static inline std::string NAMESPACE_RDF = "rdf";
+    const static inline std::string NAMESPACE_IRI_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    const static inline std::string PREFIX_DECL_RDF = MakePrefixDecl(NAMESPACE_RDF, NAMESPACE_IRI_RDF);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_META_AND_TAGS_QUERY {
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
-            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
-            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
-    };
+    const static inline std::string NAMESPACE_XSD = "xsd";
+    const static inline std::string NAMESPACE_IRI_XSD = "http://www.w3.org/2001/XMLSchema#";
+    const static inline std::string PREFIX_DECL_XSD = MakePrefixDecl(NAMESPACE_XSD, NAMESPACE_IRI_XSD);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_GEOMETRY_QUERY {
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
-            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
-            "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
-    };
+    const static inline std::string NAMESPACE_WD = "wd";
+    const static inline std::string NAMESPACE_IRI_WD = "http://www.wikidata.org/entity/";
+    const static inline std::string PREFIX_DECL_WD = MakePrefixDecl(NAMESPACE_WD, NAMESPACE_IRI_WD);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_GEOMETRY_QUERY {
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
-            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
-            "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
-    };
+    const static inline std::string NAMESPACE_OGC = "ogc";
+    const static inline std::string NAMESPACE_IRI_OGC = "http://www.opengis.net/rdf#";
+    const static inline std::string PREFIX_DECL_OGC = MakePrefixDecl(NAMESPACE_OGC, NAMESPACE_IRI_OGC);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_QUERY {
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX ogc: <http://www.opengis.net/rdf#>",
-            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>"
-    };
+    const static inline std::string NAMESPACE_GEO = "geo";
+    const static inline std::string NAMESPACE_IRI_GEO = "http://www.opengis.net/ont/geosparql#";
+    const static inline std::string PREFIX_DECL_GEO = MakePrefixDecl(NAMESPACE_GEO, NAMESPACE_IRI_GEO);
 
-    const static inline std::vector<std::string> PREFIXES_FOR_WAYS_REFERENCING_NODE {
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
-            "PREFIX osmnode: <https://www.openstreetmap.org/node/>"
-    };
+    /// Names --------------------------------------------------------------------------------------
+    const static inline std::string NAME_MEMBER = "member";
+    const static inline std::string NAME_MEMBER_ID = "member_id";
+    const static inline std::string NAME_MEMBER_POS = "member_pos";
+    const static inline std::string NAME_MEMBER_ROLE = "member_role";
+    const static inline std::string NAME_MEMBER_IDS = "member_ids";
+    const static inline std::string NAME_MEMBER_POSS = "member_poss";
+    const static inline std::string NAME_MEMBER_ROLES = "member_roles";
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATIONS_REFERENCING_NODE {
-            "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>",
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX osmnode: <https://www.openstreetmap.org/node/>"
-    };
+    const static inline std::string NAME_HAS_GEOMETRY = "hasGeometry";
+    const static inline std::string NAME_HAS_CENTROID = "hasCentroid";
+    const static inline std::string NAME_AS_WKT = "asWKT";
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATIONS_REFERENCING_WAY {
-            "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>",
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-            "PREFIX osmway: <https://www.openstreetmap.org/way/>"
-    };
+    const static inline std::string NAME_FACTS = "facts";
+    const static inline std::string NAME_AREA = "area";
+    const static inline std::string NAME_LENGTH = "length";
+    const static inline std::string NAME_OBB = "obb";
+    const static inline std::string NAME_ENVELOPE = "envelope";
+    const static inline std::string NAME_CONVEX_HULL = "convex_hull";
+    const static inline std::string NAME_TYPE = "type";
+    const static inline std::string NAME_KEY = "key";
+    const static inline std::string NAME_VALUE = "value";
+    const static inline std::string NAME_LOCATION = "location";
+    const static inline std::string NAME_TIMESTAMP = "timestamp";
+    const static inline std::string NAME_VERSION = "version";
+    const static inline std::string NAME_CHANGESET = "changeset";
+    const static inline std::string NAME_OSM_NODE_ =  "osm_node_";
+    const static inline std::string NAME_NODE =  "node";
+    const static inline std::string NAME_NODES =  "nodes";
 
-    const static inline std::vector<std::string> PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS {
-            "PREFIX osm2rdfmember: <https://osm2rdf.cs.uni-freiburg.de/rdf/member#>",
-            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
-    };
+    /// Prefixed names -----------------------------------------------------------------------------
+    static std::string MakePrefixedName(const std::string &prefix, const std::string &name) {
+        return prefix + ":" + name;
+    }
+    const static inline std::string PREFIXED_WAY_MEMBER = MakePrefixedName(NAMESPACE_OSM_WAY, NAME_MEMBER);
+    const static inline std::string PREFIXED_WAY_MEMBER_ID = MakePrefixedName(NAMESPACE_OSM_WAY, NAME_MEMBER_ID);
+    const static inline std::string PREFIXED_WAY_MEMBER_POS = MakePrefixedName(NAMESPACE_OSM_WAY, NAME_MEMBER_POS);
 
+    const static inline std::string PREFIXED_RELATION_MEMBER = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER);
+    const static inline std::string PREFIXED_RELATION_MEMBER_ID = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ID);
+    const static inline std::string PREFIXED_RELATION_MEMBER_POS = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_POS);
+    const static inline std::string PREFIXED_RELATION_MEMBER_ROLE = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ROLE);
+
+    const static inline std::string PREFIXED_GEO_HAS_GEOMETRY = MakePrefixedName(NAMESPACE_GEO, NAME_HAS_GEOMETRY);
+    const static inline std::string PREFIXED_GEO_HAS_CENTROID = MakePrefixedName(NAMESPACE_GEO, NAME_HAS_CENTROID);
+    const static inline std::string PREFIXED_GEO_AS_WKT = MakePrefixedName(NAMESPACE_GEO, NAME_AS_WKT);
+
+    const static inline std::string PREFIXED_OSM2RDF_FACTS = MakePrefixedName(NAMESPACE_OSM2RDF, NAME_FACTS);
+    const static inline std::string PREFIXED_OSM2RDF_AREA = MakePrefixedName(NAMESPACE_OSM2RDF, NAME_AREA);
+    const static inline std::string PREFIXED_OSM2RDF_LENGTH = MakePrefixedName(NAMESPACE_OSM2RDF, NAME_LENGTH);
+    const static inline std::string PREFIXED_OSM2RDF_GEOM_OBB = MakePrefixedName(NAMESPACE_OSM2RDF_GEOM, NAME_OBB);
+    const static inline std::string PREFIXED_OSM2RDF_GEOM_ENVELOPE = MakePrefixedName(NAMESPACE_OSM2RDF_GEOM, NAME_ENVELOPE);
+    const static inline std::string PREFIXED_OSM2RDF_GEOM_CONVEX_HULL = MakePrefixedName(NAMESPACE_OSM2RDF_GEOM, NAME_CONVEX_HULL);
+    const static inline std::string PREFIXED_OSM2RDF_GEOM_NODE_ = MakePrefixedName(NAMESPACE_OSM2RDF_GEOM, NAME_OSM_NODE_);
+
+    const static inline std::string PREFIXED_OSM_NODE = MakePrefixedName(NAMESPACE_OSM, NAME_NODE);
+    const static inline std::string PREFIXED_OSM_KEY_TYPE = MakePrefixedName(NAMESPACE_OSM_KEY, NAME_TYPE);
+    const static inline std::string PREFIXED_OSM_META_TIMESTAMP = MakePrefixedName(NAMESPACE_OSM_META, NAME_TIMESTAMP);
+    const static inline std::string PREFIXED_OSM_META_VERSION = MakePrefixedName(NAMESPACE_OSM_META, NAME_VERSION);
+    const static inline std::string PREFIXED_OSM_META_CHANGESET = MakePrefixedName(NAMESPACE_OSM_META, NAME_CHANGESET);
+
+    const static inline std::string PREFIXED_RDF_TYPE = MakePrefixedName(NAMESPACE_RDF, NAME_TYPE);
+
+    /// Prefix declarations ------------------------------------------------------------------------
+    const static inline std::vector DEFAULT_PREFIXES {
+            PREFIX_DECL_OSM, PREFIX_DECL_OSM_NODE, PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_KEY, PREFIX_DECL_OSM_META,
+            PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM2RDF_KEY, PREFIX_DECL_OSM2RDF_GEOM, PREFIX_DECL_OSM2RDF_META, PREFIX_DECL_OSM2RDF_GENID, PREFIX_DECL_OSM2RDF_MEMBER,
+            PREFIX_DECL_WD, PREFIX_DECL_GEO, PREFIX_DECL_OGC, PREFIX_DECL_RDF, PREFIX_DECL_XSD};
+
+    const static inline std::vector PREFIXES_FOR_NODE_LOCATION {
+            PREFIX_DECL_OSM_NODE, PREFIX_DECL_GEO, PREFIX_DECL_OSM2RDF_GEOM};
+
+    const static inline std::vector PREFIXES_FOR_RELATION_MEMBERS{
+            PREFIX_DECL_OSM_REL, PREFIX_DECL_RDF, PREFIX_DECL_OSM2RDF_MEMBER, PREFIX_DECL_OSM, PREFIX_DECL_OSM_KEY};
+
+    const static inline std::vector PREFIXES_FOR_WAY_MEMBERS{
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM2RDF_MEMBER};
+
+    const static inline std::vector PREFIXES_FOR_WAY_TAGS_AND_META_INFO{
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM_KEY};
+
+    const static inline std::vector PREFIXES_FOR_RELATION_TAGS_AND_META_INFO{
+            PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM_KEY};
+
+    const static inline std::vector PREFIXES_FOR_LATEST_NODE_TIMESTAMP {
+            PREFIX_DECL_OSM_META, PREFIX_DECL_OSM, PREFIX_DECL_RDF};
+
+    const static inline std::vector PREFIXES_FOR_NODE_DELETE_QUERY {
+            PREFIX_DECL_OSM_NODE, PREFIX_DECL_OGC, PREFIX_DECL_GEO};
+
+    const static inline std::vector PREFIXES_FOR_WAY_DELETE_QUERY {
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_OGC, PREFIX_DECL_GEO};
+
+    const static inline std::vector PREFIXES_FOR_WAY_DELETE_META_AND_TAGS_QUERY {
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM_KEY};
+
+    const static inline std::vector PREFIXES_FOR_WAY_DELETE_GEOMETRY_QUERY {
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_GEO, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM2RDF_GEOM};
+
+    const static inline std::vector PREFIXES_FOR_RELATION_DELETE_GEOMETRY_QUERY {
+            PREFIX_DECL_OSM_REL, PREFIX_DECL_GEO, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM2RDF_GEOM};
+
+    const static inline std::vector PREFIXES_FOR_RELATION_DELETE_QUERY {
+            PREFIX_DECL_OSM_REL, PREFIX_DECL_OGC, PREFIX_DECL_GEO};
+
+    const static inline std::vector PREFIXES_FOR_WAYS_REFERENCING_NODE {
+            PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM_NODE};
+
+    const static inline std::vector PREFIXES_FOR_RELATIONS_REFERENCING_NODE {
+            PREFIX_DECL_OSM2RDF_MEMBER, PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_NODE};
+
+    const static inline std::vector PREFIXES_FOR_RELATIONS_REFERENCING_WAY {
+            PREFIX_DECL_OSM2RDF_MEMBER, PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_WAY};
+
+    const static inline std::vector PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS {
+            PREFIX_DECL_OSM2RDF_MEMBER, PREFIX_DECL_OSM_REL};
+
+    // Query variables -----------------------------------------------------------------------------
+    static std::string MakeQueryVar(const std::string &name) {
+            return "?" + name;
+    }
+    const static inline std::string QUERY_VAR_TYPE = MakeQueryVar(NAME_TYPE);
+    const static inline std::string QUERY_VAR_KEY = MakeQueryVar(NAME_KEY);
+    const static inline std::string QUERY_VAR_VAL = MakeQueryVar(NAME_VALUE);
+    const static inline std::string QUERY_VAR_LOC = MakeQueryVar(NAME_LOCATION);
+    const static inline std::string QUERY_VAR_TIMESTAMP = MakeQueryVar(NAME_TIMESTAMP);
+    const static inline std::string QUERY_VAR_VERSION = MakeQueryVar(NAME_VERSION);
+    const static inline std::string QUERY_VAR_CHANGESET = MakeQueryVar(NAME_CHANGESET);
+    const static inline std::string QUERY_VAR_NODES = MakeQueryVar(NAME_NODES);
+    const static inline std::string QUERY_VAR_MEMBER = MakeQueryVar(NAME_MEMBER);
+    const static inline std::string QUERY_VAR_MEMBER_ID = MakeQueryVar(NAME_MEMBER_ID);
+    const static inline std::string QUERY_VAR_MEMBER_ROLE = MakeQueryVar(NAME_MEMBER_ROLE);
+    const static inline std::string QUERY_VAR_MEMBER_POS = MakeQueryVar(NAME_MEMBER_POS);
+    const static inline std::string QUERY_VAR_MEMBER_IDS = MakeQueryVar(NAME_MEMBER_IDS);
+    const static inline std::string QUERY_VAR_MEMBER_ROLES = MakeQueryVar(NAME_MEMBER_ROLES);
+    const static inline std::string QUERY_VAR_MEMBER_POSS = MakeQueryVar(NAME_MEMBER_POSS);
+
+    // Options and output --------------------------------------------------------------------------
     const static inline std::string HEADER = "Configuration for OLU:";
 
     const static inline std::string HELP_OPTION_SHORT = "h";

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -57,6 +57,7 @@ namespace olu::config::constants {
     const static inline std::string PATH_TO_INPUT_FILE = PATH_TO_TEMP_DIR + "input" + OSM_EXTENSION;
     const static inline std::string PATH_TO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "output" + TURTLE_FILE_EXTENSION;
     const static inline std::string PATH_TO_OSM2RDF_INFO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "osm2rdf_info" + TEXT_FILE_EXTENSION;
+    const static inline std::string PATH_TO_OSM2RDF_INFO_OUTPUT_FILE_DEBUG = "osm2rdf_info" + TEXT_FILE_EXTENSION;
     const static inline std::string PATH_TO_STATE_FILE = "state" + TEXT_FILE_EXTENSION;
 
     // XML -----------------------------------------------------------------------------------------

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -182,6 +182,13 @@ namespace olu::config::constants {
             "PREFIX geo: <http://www.opengis.net/ont/geosparql#>"
     };
 
+    const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_META_AND_TAGS_QUERY {
+            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
+            "PREFIX osmmeta: <https://www.openstreetmap.org/meta/>",
+            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
+            "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
+    };
+
     const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_QUERY {
             "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
             "PREFIX ogc: <http://www.opengis.net/rdf#>",

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -70,6 +70,7 @@ namespace olu::config::constants {
     const static inline std::string XML_TAG_REF = "ref";
     const static inline std::string XML_TAG_MEMBER = "member";
     const static inline std::string XML_TAG_TYPE = "type";
+    const static inline std::string XML_TAG_ROLE = "role";
     const static inline std::string XML_TAG_ID = "id";
     const static inline std::string XML_TAG_LAT = "lat";
     const static inline std::string XML_TAG_LON = "lon";
@@ -106,6 +107,7 @@ namespace olu::config::constants {
     const static inline std::string XML_PATH_ATTR_LAT = MakeXMLPath({XML_TAG_ATTR, XML_TAG_LAT});
     const static inline std::string XML_PATH_ATTR_LON = MakeXMLPath({XML_TAG_ATTR, XML_TAG_LON});
     const static inline std::string XML_PATH_ATTR_TYPE = MakeXMLPath({XML_TAG_ATTR, XML_TAG_TYPE});
+    const static inline std::string XML_PATH_ATTR_ROLE = MakeXMLPath({XML_TAG_ATTR, XML_TAG_ROLE});
     const static inline std::string XML_PATH_ATTR_KEY = MakeXMLPath({XML_TAG_ATTR, XML_TAG_KEY});
     const static inline std::string XML_PATH_ATTR_VALUE = MakeXMLPath({XML_TAG_ATTR, XML_TAG_VALUE});
     const static inline std::string XML_PATH_ATTR_NAME = MakeXMLPath({XML_TAG_ATTR, XML_TAG_NAME});
@@ -224,10 +226,10 @@ namespace olu::config::constants {
     const static inline std::string PREFIXED_WAY_MEMBER_ID = MakePrefixedName(NAMESPACE_OSM_WAY, NAME_MEMBER_ID);
     const static inline std::string PREFIXED_WAY_MEMBER_POS = MakePrefixedName(NAMESPACE_OSM_WAY, NAME_MEMBER_POS);
 
-    const static inline std::string PREFIXED_RELATION_MEMBER = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER);
-    const static inline std::string PREFIXED_RELATION_MEMBER_ID = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ID);
-    const static inline std::string PREFIXED_RELATION_MEMBER_POS = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_POS);
-    const static inline std::string PREFIXED_RELATION_MEMBER_ROLE = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ROLE);
+    const static inline std::string PREFIXED_REL_MEMBER = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER);
+    const static inline std::string PREFIXED_REL_MEMBER_ID = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ID);
+    const static inline std::string PREFIXED_REL_MEMBER_POS = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_POS);
+    const static inline std::string PREFIXED_REL_MEMBER_ROLE = MakePrefixedName(NAMESPACE_OSM_REL, NAME_MEMBER_ROLE);
 
     const static inline std::string PREFIXED_GEO_HAS_GEOMETRY = MakePrefixedName(NAMESPACE_GEO, NAME_HAS_GEOMETRY);
     const static inline std::string PREFIXED_GEO_HAS_CENTROID = MakePrefixedName(NAMESPACE_GEO, NAME_HAS_CENTROID);
@@ -281,6 +283,9 @@ namespace olu::config::constants {
 
     const static inline std::vector PREFIXES_FOR_WAY_DELETE_META_AND_TAGS_QUERY {
             PREFIX_DECL_OSM_WAY, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM_KEY};
+
+    const static inline std::vector PREFIXES_FOR_RELATION_DELETE_META_AND_TAGS_QUERY {
+            PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM_KEY};
 
     const static inline std::vector PREFIXES_FOR_WAY_DELETE_GEOMETRY_QUERY {
             PREFIX_DECL_OSM_WAY, PREFIX_DECL_GEO, PREFIX_DECL_OSM2RDF, PREFIX_DECL_OSM2RDF_GEOM};

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 namespace olu::config::constants {
+
     // Exception Messages
     const static inline char *const EXCEPTION_MSG_SEQUENCE_NUMBER_IS_INVALID =
         "Sequence number is invalid.";
@@ -81,6 +82,10 @@ namespace olu::config::constants {
     const static inline std::string OSM_TAG_KEY = "https://www.openstreetmap.org/wiki/Key:";
 
     // osm2rdf predicates
+    const static inline std::string OSM_NODE_PREFIX = "osmnode";
+    const static inline std::string OSM_WAY_PREFIX = "osmway";
+    const static inline std::string OSM_RELATION_PREFIX = "osmrel";
+
     const static inline std::string OSM_2_RDF_WAY_MEMBER = "osmway:member";
     const static inline std::string OSM_2_RDF_WAY_MEMBER_ID = "osmway:member_id";
     const static inline std::string OSM_2_RDF_WAY_MEMBER_POS = "osmway:member_pos";
@@ -196,6 +201,13 @@ namespace olu::config::constants {
             "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
     };
 
+    const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_GEOMETRY_QUERY {
+            "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
+            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
+            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
+            "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
+    };
+
     const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_QUERY {
             "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
             "PREFIX ogc: <http://www.opengis.net/rdf#>",
@@ -224,7 +236,6 @@ namespace olu::config::constants {
             "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
     };
 
-    // Qlever
     const static inline std::string HEADER = "Configuration for OLU:";
 
     const static inline std::string HELP_OPTION_SHORT = "h";

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -189,6 +189,13 @@ namespace olu::config::constants {
             "PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>"
     };
 
+    const static inline std::vector<std::string> PREFIXES_FOR_WAY_DELETE_GEOMETRY_QUERY {
+            "PREFIX osmway: <https://www.openstreetmap.org/way/>",
+            "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
+            "PREFIX osm2rdf: <https://osm2rdf.cs.uni-freiburg.de/rdf#>",
+            "PREFIX osm2rdfgeom: <https://osm2rdf.cs.uni-freiburg.de/rdf/geom#>"
+    };
+
     const static inline std::vector<std::string> PREFIXES_FOR_RELATION_DELETE_QUERY {
             "PREFIX osmrel: <https://www.openstreetmap.org/relation/>",
             "PREFIX ogc: <http://www.opengis.net/rdf#>",

--- a/include/osm/Node.h
+++ b/include/osm/Node.h
@@ -28,7 +28,7 @@ namespace olu::osm {
 
     class Node {
     public:
-        explicit Node(id_t id, const WKTPoint& locationAsWkt);
+        explicit Node(id_t id, const wktPoint_t& locationAsWkt);
 
         /**
          * Returns the node as a xml osm object.

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -278,6 +278,13 @@ namespace olu::osm {
         void deleteRelationsFromDatabase(osm2rdf::util::ProgressBar &progress, size_t &counter);
 
         /**
+         * Send SPARQL queries to delete geometry triples that belong to the ways for which only the
+         * geometry changed
+         */
+        void deleteRelationsGeometry(osm2rdf::util::ProgressBar &progress, size_t &counter);
+
+
+        /**
          * Send SPARQL queries to insert all relevant triples
          */
         void insertTriplesToDatabase();

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -312,7 +312,7 @@ namespace olu::osm {
          * elements that occurred in the change file or osm elements which geometry needs to be
          * updated. Irrelevant triples are triples that where generated for referenced elements.
          */
-        std::vector<Triple> filterRelevantTriples();
+        std::vector<triple_t> filterRelevantTriples();
 
         /**
          * Returns the elements id.

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -266,6 +266,12 @@ namespace olu::osm {
         void deleteWaysMetaDataAndTags(osm2rdf::util::ProgressBar &progress, size_t &counter);
 
         /**
+         * Send SPARQL queries to delete geometry triples that belong to the ways for which only the
+         * geometry changed
+         */
+        void deleteWaysGeometry(osm2rdf::util::ProgressBar &progress, size_t &counter);
+
+        /**
         * Send SPARQL queries to delete all triples that belong to the relations that are inserted to
         * the database
         */

--- a/include/osm/OsmDataFetcher.h
+++ b/include/osm/OsmDataFetcher.h
@@ -19,7 +19,6 @@
 #ifndef OSM_LIVE_UPDATES_OSMDATAFETCHER_H
 #define OSM_LIVE_UPDATES_OSMDATAFETCHER_H
 
-#include "osm/OsmDatabaseState.h"
 #include "osm/Node.h"
 #include "osm/Relation.h"
 #include "osm/Way.h"
@@ -33,52 +32,13 @@
 namespace olu::osm {
 
     /**
-     * Deals with the retrieval of osm data needed for the update process.
-     *
-     * Osm change files are fetched from the server, the URL of which must be provided by the user.
-     * The remaining data is collected from the SPARQL endpoint.
+     * Deals with the retrieval of osm data from the SPARQL endpoint that is needed for the update
+     * process.
      */
     class OsmDataFetcher {
     public:
         explicit OsmDataFetcher(const config::Config &config)
             : _config(config), _sparqlWrapper(config), _queryWriter(config) { }
-
-        // Fetch from SERVER -----------------------------------------------------------------------
-        /**
-         * Fetches the database state (sequence number and timestamp) for the given sequence number
-         * from the server
-         *
-         * @param sequenceNumber the sequence number to fetch the database state for
-         * @return The database state for the provided sequence number
-         */
-        [[nodiscard]] OsmDatabaseState fetchDatabaseState(int sequenceNumber) const;
-
-        /**
-         * Fetches the database state (sequence number and timestamp) of the latest diff from the
-         * server
-         *
-         * @return The latest database state on the server
-         */
-        [[nodiscard]] OsmDatabaseState fetchLatestDatabaseState() const;
-
-        /**
-         * Fetches the .osc change file from the server, writes it to a file and returns the path to
-         * the file. The file might be compressed with gzip.
-         *
-         * @param sequenceNumber The sequence number to fetch the change file for
-         * @return The path to the location of the fetched .osm Change file
-         */
-        std::string fetchChangeFile(int &sequenceNumber) ;
-
-        /**
-         * Fetches the 'nearest' database state for the given timestamp from the server, meaning the
-         * first state which timestamp is before the given timestamp.
-         *
-         * @param timeStamp Timestamp to fetch the `nearest` database state for
-         * @return The 'nearest' database state for the given timestamp
-         */
-        [[nodiscard]] OsmDatabaseState
-        fetchDatabaseStateForTimestamp(const std::string& timeStamp) const;
 
         /**
          * Sends a query to the sparql endpoint to get the location of the nodes with the given ids
@@ -189,15 +149,6 @@ namespace olu::osm {
         config::Config _config;
         sparql::SparqlWrapper _sparqlWrapper;
         sparql::QueryWriter _queryWriter;
-
-        /**
-         * Extracts the database state from a state file. A state file contains a sequence number
-         * and a timestamp and describes the state for an osm change file.
-         *
-         * @param stateFile The state file to extract the database state from.
-         * @return The database state described by the state file
-         */
-        static OsmDatabaseState extractStateFromStateFile(const std::string& stateFile);
 
         boost::property_tree::ptree runQuery(const std::string &query,
                                              const std::vector<std::string> &prefixes);

--- a/include/osm/OsmDataFetcher.h
+++ b/include/osm/OsmDataFetcher.h
@@ -145,6 +145,14 @@ namespace olu::osm {
         fetchWaysMembersSorted(const std::set<id_t> &wayIds);
 
         /**
+          * Sends a query to the sparql endpoint to get the members of the given relations
+          *
+          * @return The subjects of all members
+          */
+        std::vector<std::pair<id_t, rel_members_t>>
+        fetchRelsMembersSorted(const std::set<id_t> &relIds);
+
+        /**
          * @return The ids of all nodes and ways that are referenced by the given relations
          */
         std::pair<std::vector<id_t>, std::vector<id_t>>
@@ -196,6 +204,8 @@ namespace olu::osm {
 
         static std::vector<int> extractPositions(const std::string& positions);
         static std::vector<id_t> extractMembers(const std::string& memberUris);
+        static std::vector<std::string> extractMemberTags(const std::string& memberUris);
+        static std::vector<std::string> extractRoles(const std::string& memberRoles);
     };
 
     /**

--- a/include/osm/OsmDataFetcher.h
+++ b/include/osm/OsmDataFetcher.h
@@ -133,7 +133,16 @@ namespace olu::osm {
           *
           * @return The subjects of all members
           */
-        std::vector<id_t> fetchWaysMembers(const std::set<id_t> &wayIds);
+        member_ids_t fetchWaysMembers(const std::set<id_t> &wayIds);
+
+        /**
+          * Sends a query to the sparql endpoint to get the ids of all nodes that are referenced
+          * in the given way
+          *
+          * @return The subjects of all members
+          */
+        std::vector<std::pair<id_t, member_ids_t>>
+        fetchWaysMembersSorted(const std::set<id_t> &wayIds);
 
         /**
          * @return The ids of all nodes and ways that are referenced by the given relations
@@ -184,6 +193,9 @@ namespace olu::osm {
 
         boost::property_tree::ptree runQuery(const std::string &query,
                                              const std::vector<std::string> &prefixes);
+
+        static std::vector<int> extractPositions(const std::string& positions);
+        static std::vector<id_t> extractMembers(const std::string& memberUris);
     };
 
     /**

--- a/include/osm/OsmReplicationServerHelper.h
+++ b/include/osm/OsmReplicationServerHelper.h
@@ -1,0 +1,106 @@
+// Copyright 2024, University of Freiburg
+// Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
+
+// This file is part of osm-live-updates.
+//
+// osm-live-updates is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm-live-updates is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef OSMREPLICATIONSERVERHELPER_H
+#define OSMREPLICATIONSERVERHELPER_H
+
+#include "config/Config.h"
+#include "osm/OsmDatabaseState.h"
+
+namespace olu::osm {
+    /**
+     *  Deals with the retrieval of osm change files from the replication server that is specified
+     *  by the user.
+     */
+    class OsmReplicationServerHelper {
+    public:
+        explicit OsmReplicationServerHelper(config::Config config): _config(std::move(config)) { }
+
+        /**
+         * Fetches the database state (sequence number and timestamp) for the given sequence number
+         * from the server
+         *
+         * @param sequenceNumber the sequence number to fetch the database state for
+         * @return The database state for the provided sequence number
+         */
+        [[nodiscard]] OsmDatabaseState fetchDatabaseStateForSeqNumber(int sequenceNumber) const;
+
+        /**
+         * Fetches the database state (sequence number and timestamp) of the latest diff from the
+         * server
+         *
+         * @return The latest database state on the server
+         */
+        [[nodiscard]] OsmDatabaseState fetchLatestDatabaseState() const;
+
+        /**
+         * Fetches the .osc change file from the server, writes it to a file and returns the path to
+         * the file. The file might be compressed with gzip.
+         *
+         * @param sequenceNumber The sequence number to fetch the change file for
+         * @return The path to the location of the fetched .osm Change file
+         */
+        std::string fetchChangeFile(int &sequenceNumber) ;
+
+        /**
+         * Fetches the 'nearest' database state for the given timestamp from the server, meaning the
+         * first state which timestamp is before the given timestamp.
+         *
+         * @param timeStamp Timestamp to fetch the `nearest` database state for
+         * @return The 'nearest' database state for the given timestamp
+         */
+        [[nodiscard]] OsmDatabaseState
+        fetchDatabaseStateForTimestamp(const std::string& timeStamp) const;
+    private:
+        config::Config _config;
+
+        /**
+         * Sends a HTTP request to the replication server and tries to extract a data base state
+         * from the returned state file.
+         *
+         * @param stateFilePath The path of the state file on the replication server
+         * @return The database state for the state file at the provided file path
+         */
+        OsmDatabaseState fetchDatabaseStateFromUrl(const std::string& stateFilePath) const;
+
+        /**
+         * Extracts the database state from a state file. A state file contains a sequence number
+         * and a timestamp and describes the state for an osm change file.
+         *
+         * @param stateFile The state file to extract the database state from.
+         * @return The database state described by the state file
+         */
+        static OsmDatabaseState extractStateFromStateFile(const std::string& stateFile);
+    };
+
+    /**
+     * Exception that can appear inside the `OsmReplicationServerHelper` class.
+     */
+    class OsmReplicationServerHelperException final : public std::exception {
+        std::string message;
+    public:
+        explicit OsmReplicationServerHelperException(const char* msg) : message(msg) { }
+
+        [[nodiscard]] const char* what() const noexcept override {
+            return message.c_str();
+        }
+    };
+
+}
+
+#endif //OSMREPLICATIONSERVERHELPER_H

--- a/include/osm/OsmUpdater.h
+++ b/include/osm/OsmUpdater.h
@@ -5,11 +5,10 @@
 #ifndef OSM_LIVE_UPDATES_OSMUPDATER_H
 #define OSM_LIVE_UPDATES_OSMUPDATER_H
 
-#include <iostream>
-
 #include "config/Config.h"
 #include "osm/OsmDatabaseState.h"
 #include "osm/OsmDataFetcher.h"
+#include "osm/OsmReplicationServerHelper.h"
 
 namespace olu::osm {
 
@@ -28,6 +27,7 @@ namespace olu::osm {
         void run();
     private:
         config::Config _config;
+        OsmReplicationServerHelper _repServer;
         OsmDataFetcher _odf;
         OsmDatabaseState _latestState;
 
@@ -50,7 +50,7 @@ namespace olu::osm {
         [[nodiscard]] int decideStartSequenceNumber();
 
         /**
-        * Download all change files from the given seqence number to the `latest` one, and store
+        * Download all change files from the given sequence number to the `latest` one, and store
         * them in the /changes directory.
         */
         void fetchChangeFiles(int sequenceNumber);

--- a/include/osm/Relation.h
+++ b/include/osm/Relation.h
@@ -55,7 +55,7 @@ namespace olu::osm {
 
         rel_members_t getMembers() { return members; }
         [[nodiscard]] id_t getId() const { return id; }
-        std::vector<KeyValue> getTags() { return tags; }
+        std::vector<key_value_t> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
         [[nodiscard]] version_t getVersion() const { return version; }
         [[nodiscard]] changeset_id_t getChangesetId() const { return changeset_id; }
@@ -66,7 +66,7 @@ namespace olu::osm {
         changeset_id_t changeset_id = 0;
         std::string type;
         rel_members_t members;
-        std::vector<KeyValue> tags;
+        std::vector<key_value_t> tags;
     };
 
     /**

--- a/include/osm/Relation.h
+++ b/include/osm/Relation.h
@@ -24,19 +24,8 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <set>
 
 namespace olu::osm {
-
-    struct RelationMember {
-        id_t id;
-        std::string osmTag;
-        std::string role;
-
-        RelationMember(const id_t id, const std::string &osmTag, const std::string &role) :
-        id(id), osmTag(osmTag), role(role) {}
-    };
-
     class Relation {
     public:
         explicit Relation(const id_t id): id(id) {};
@@ -64,7 +53,7 @@ namespace olu::osm {
          */
         [[nodiscard]] std::string getXml() const;
 
-        std::vector<RelationMember> getMembers() { return members; }
+        rel_members_t getMembers() { return members; }
         [[nodiscard]] id_t getId() const { return id; }
         std::vector<KeyValue> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
@@ -76,7 +65,7 @@ namespace olu::osm {
         version_t version = 0;
         changeset_id_t changeset_id = 0;
         std::string type;
-        std::vector<RelationMember> members;
+        rel_members_t members;
         std::vector<KeyValue> tags;
     };
 

--- a/include/osm/RelationMember.h
+++ b/include/osm/RelationMember.h
@@ -16,27 +16,24 @@
 // You should have received a copy of the GNU General Public License
 // along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef OSM_LIVE_UPDATES_TYPES_H
-#define OSM_LIVE_UPDATES_TYPES_H
+#ifndef RELATIONMEMBER_H
+#define RELATIONMEMBER_H
 
-#include <cstdint>
+#include "util/Types.h"
+
 #include <string>
-#include <tuple>
-#include <vector>
-#include <osm/RelationMember.h>
+#include <utility>
 
-namespace olu {
+namespace olu::osm {
 
-    typedef int64_t id_t;
-    typedef uint32_t changeset_id_t;
-    typedef uint32_t version_t;
-    typedef std::vector<id_t> member_ids_t;
-    typedef std::vector<osm::RelationMember> rel_members_t;
+    struct RelationMember {
+        int64_t id;
+        std::string osmTag;
+        std::string role;
 
-    typedef std::string WKTPoint;
-
-    typedef std::tuple<std::string, std::string, std::string> Triple;
-    typedef std::pair<std::string, std::string> KeyValue;
+        RelationMember(const int64_t id, std::string osmTag, std::string role) :
+        id(id), osmTag(std::move(osmTag)), role(std::move(role)) {}
+    };
 }
 
-#endif //OSM_LIVE_UPDATES_TYPES_H
+#endif //RELATIONMEMBER_H

--- a/include/osm/Way.h
+++ b/include/osm/Way.h
@@ -45,7 +45,7 @@ namespace olu::osm {
         */
         [[nodiscard]] std::string getXml() const;
 
-        std::vector<id_t> getMembers() { return members; }
+        member_ids_t getMembers() { return members; }
         [[nodiscard]] id_t getId() const { return id; }
         std::vector<KeyValue> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
@@ -56,7 +56,7 @@ namespace olu::osm {
         std::string timestamp;
         version_t version = 0;
         changeset_id_t changeset_id = 0;
-        std::vector<id_t> members;
+        member_ids_t members;
         std::vector<KeyValue> tags;
     };
 

--- a/include/osm/Way.h
+++ b/include/osm/Way.h
@@ -47,7 +47,7 @@ namespace olu::osm {
 
         member_ids_t getMembers() { return members; }
         [[nodiscard]] id_t getId() const { return id; }
-        std::vector<KeyValue> getTags() { return tags; }
+        std::vector<key_value_t> getTags() { return tags; }
         std::string getTimestamp() { return timestamp; }
         [[nodiscard]] version_t getVersion() const { return version; }
         [[nodiscard]] changeset_id_t getChangesetId() const { return changeset_id; }
@@ -57,7 +57,7 @@ namespace olu::osm {
         version_t version = 0;
         changeset_id_t changeset_id = 0;
         member_ids_t members;
-        std::vector<KeyValue> tags;
+        std::vector<key_value_t> tags;
     };
 
     /**

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -76,9 +76,15 @@ namespace olu::sparql {
         [[nodiscard]] std::string writeQueryForRelations(const std::set<id_t> & relationIds) const;
 
         /**
-        * @returns A SPARQL query for the subject of all members of the given relation
+        * @returns A SPARQL query for the members of the given ways with their position.
         */
         [[nodiscard]] std::string writeQueryForWaysMembers(const std::set<id_t> &wayIds) const;
+
+        /**
+        * @returns A SPARQL query for the members of the given relations with their position and
+        * roles.
+        */
+        [[nodiscard]] std::string writeQueryForRelsMembers(const std::set<id_t> &relIds) const;
 
         /**
          * @returns A SPARQL query for all nodes that are referenced by the given way
@@ -88,7 +94,7 @@ namespace olu::sparql {
         /**
          * @returns A SPARQL query for all members of the given relations
          */
-        [[nodiscard]] std::string writeQueryForRelationMembers(const std::set<id_t> &relIds) const;
+        [[nodiscard]] std::string writeQueryForRelationMemberIds(const std::set<id_t> &relIds) const;
 
         /**
         * @returns A SPARQL query for all ways that reference the given nodes

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -44,7 +44,15 @@ namespace olu::sparql {
          * @returns A SPARQL query that delete all triples with subject `osmTag:id` and all triples
          * that are linked via another node
          */
-        [[nodiscard]] std::string writeDeleteQuery(const std::set<id_t> &ids, const std::string &osmTag) const;
+        [[nodiscard]] std::string
+        writeDeleteQuery(const std::set<id_t> &ids, const std::string &osmTag) const;
+
+        /**
+         * @returns A SPARQL query that delete all triples with predicate 'osmmeta:...',
+         * 'osm2rdf:facts' and 'osmkey:...' for subject `osmTag:id`
+         */
+        [[nodiscard]] std::string
+        writeDeleteQueryForMetaAndTags(const std::set<id_t> &ids, const std::string &osmTag) const;
 
         /**
         * @returns A SPARQL query for the locations of the nodes with the given ID in WKT format

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -123,12 +123,17 @@ namespace olu::sparql {
         [[nodiscard]] static std::string getValuesClause(const std::string& osmTag,
                                                          const std::set<id_t> &objectIds);
 
+        [[nodiscard]] static std::string getValuesClause(const std::string& osmTag,
+                                                         const std::string &delimiter,
+                                                         const std::set<id_t> &objectIds);
+
         [[nodiscard]] static std::string getTripleClause(const std::string& subject,
                                                          const std::string& predicate,
                                                          const std::string& object);
 
         [[nodiscard]] std::string wrapWithGraphOptional(const std::string& clause) const;
-        [[nodiscard]] static std::string wrapWithUnion(const std::string& clause) ;
+        [[nodiscard]] static std::string wrapWithUnion(const std::string& clause);
+        [[nodiscard]] static std::string wrapWithOptional(const std::string& clause);
     };
 
     /**

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -55,6 +55,12 @@ namespace olu::sparql {
         writeDeleteQueryForMetaAndTags(const std::set<id_t> &ids, const std::string &osmTag) const;
 
         /**
+         * @returns A SPARQL query that delete all geometry triples for subjects `osmTag:id`
+         */
+        [[nodiscard]] std::string
+        writeDeleteQueryForGeometry(const std::set<id_t> &ids, const std::string &osmTag) const;
+
+        /**
         * @returns A SPARQL query for the locations of the nodes with the given ID in WKT format
         */
         [[nodiscard]] std::string writeQueryForNodeLocations(const std::set<id_t> &nodeIds) const;

--- a/include/util/OsmObjectHelper.h
+++ b/include/util/OsmObjectHelper.h
@@ -21,8 +21,11 @@ namespace olu::osm {
         static bool isMultipolygon(const boost::property_tree::ptree &relation);
 
         static id_t getIdFromUri(const std::string& uri);
+        static std::string getOsmTagFromUri(const std::string& uri);
 
-        static bool areMemberEqual(member_ids_t member1, member_ids_t member2);
+        static bool areWayMemberEqual(member_ids_t member1, member_ids_t member2);
+        static bool areRelMemberEqual(rel_members_t member1, rel_members_t member2);
+
     };
 
     /**

--- a/include/util/OsmObjectHelper.h
+++ b/include/util/OsmObjectHelper.h
@@ -21,6 +21,8 @@ namespace olu::osm {
         static bool isMultipolygon(const boost::property_tree::ptree &relation);
 
         static id_t getIdFromUri(const std::string& uri);
+
+        static bool areMemberEqual(member_ids_t member1, member_ids_t member2);
     };
 
     /**

--- a/include/util/TtlHelper.h
+++ b/include/util/TtlHelper.h
@@ -13,7 +13,7 @@ namespace olu::util {
 
     class TtlHelper {
     public:
-        static Triple getTriple(const std::string& tripleString);
+        static triple_t getTriple(const std::string& tripleString);
         static id_t getIdFromSubject(const std::string& subject, const std::string &osmTag);
         static bool isRelevantNamespace(const std::string& subject, const std::string &osmTag);
         static bool hasRelevantObject(const std::string& predicate, const std::string &osmTag);

--- a/include/util/Types.h
+++ b/include/util/Types.h
@@ -22,12 +22,14 @@
 #include <cstdint>
 #include <string>
 #include <tuple>
+#include <vector>
 
 namespace olu {
 
     typedef int64_t id_t;
     typedef uint32_t changeset_id_t;
     typedef uint32_t version_t;
+    typedef  std::vector<id_t> member_ids_t;
 
     typedef std::string WKTPoint;
 

--- a/include/util/Types.h
+++ b/include/util/Types.h
@@ -33,10 +33,10 @@ namespace olu {
     typedef std::vector<id_t> member_ids_t;
     typedef std::vector<osm::RelationMember> rel_members_t;
 
-    typedef std::string WKTPoint;
+    typedef std::string wktPoint_t;
 
-    typedef std::tuple<std::string, std::string, std::string> Triple;
-    typedef std::pair<std::string, std::string> KeyValue;
+    typedef std::tuple<std::string, std::string, std::string> triple_t;
+    typedef std::pair<std::string, std::string> key_value_t;
 }
 
 #endif //OSM_LIVE_UPDATES_TYPES_H

--- a/include/util/URLHelper.h
+++ b/include/util/URLHelper.h
@@ -27,7 +27,7 @@ namespace olu::util {
 class URLHelper {
 public:
     // Builds an url from a list of strings by concatenating them with a '/'
-    static std::string buildUrl(std::vector<std::string> &pathSegments);
+    static std::string buildUrl(const std::vector<std::string> &pathSegments);
 
     // Formats a sequence number for use in an url
     // For example: The sequence number 6177383 would be returned as 006/177/383

--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -27,7 +27,7 @@
 static inline constexpr int MAX_NODE_LOC_PRECISION = 7;
 
 namespace olu::osm {
-    Node::Node(const id_t id, const WKTPoint& locationAsWkt) {
+    Node::Node(const id_t id, const wktPoint_t& locationAsWkt) {
         this->id = id;
 
         try {

--- a/src/osm/Osm2ttl.cpp
+++ b/src/osm/Osm2ttl.cpp
@@ -76,7 +76,16 @@ namespace olu::osm {
 
         try {
             // Redicret std::cout to avoid output from osm2rdf
-            const std::ofstream out(cnst::PATH_TO_OSM2RDF_INFO_OUTPUT_FILE);
+            std::string outputFile;
+
+            // Keep osm2rdf output in debug mode, otherwise write to temp dierectory and delete
+            // after done
+            if (_config.sparqlOutput == config::DEBUG_FILE) {
+                outputFile = cnst::PATH_TO_OSM2RDF_INFO_OUTPUT_FILE_DEBUG;
+            } else {
+                outputFile = cnst::PATH_TO_OSM2RDF_INFO_OUTPUT_FILE;
+            }
+            const std::ofstream out(outputFile);
             std::streambuf *coutbuf = std::cerr.rdbuf();
             std::cerr.rdbuf(out.rdbuf());
 

--- a/src/osm/Osm2ttl.cpp
+++ b/src/osm/Osm2ttl.cpp
@@ -76,7 +76,7 @@ namespace olu::osm {
 
         try {
             // Redicret std::cout to avoid output from osm2rdf
-            const std::ofstream out("osm2rdf_info.txt");
+            const std::ofstream out(cnst::PATH_TO_OSM2RDF_INFO_OUTPUT_FILE);
             std::streambuf *coutbuf = std::cerr.rdbuf();
             std::cerr.rdbuf(out.rdbuf());
 

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -105,9 +105,6 @@ namespace olu::osm {
         deleteTriplesFromDatabase();
         insertTriplesToDatabase();
 
-        // Cache of sparql endpoint has to be cleared after the completion`
-        _sparql.clearCache();
-
         const auto modifiedNodesCount = _modifiedNodes.size() +
                                                    _modifiedNodesWithChangedLocation.size();
         const auto modifiedWaysCount = _modifiedWays.size() +
@@ -323,9 +320,11 @@ namespace olu::osm {
         checkNodesForLocationChange(modifiedNodes, modifiedNodeLocations);
 
         // Check if the members of modified ways and rels have changed and store them in the
-        // responding sets
+        // responding sets (_modifiedWays/Rels or _modifiedWays/RelsWithChangedMembers)
         checkWaysForMemberChange(modifiedWaysWithMembers);
+        // std::cout << (_modifiedWaysWithChangedMembers.size() * 100 / (_modifiedWaysWithChangedMembers.size() + _modifiedWays.size())) << "% of ways have a changed member list" << std::endl;
         checkRelsForMemberChange(modifiedRelsWithMembers);
+        // std::cout << (_modifiedRelsWithChangedMembers.size() * 100 / (_modifiedRelsWithChangedMembers.size() + _modifiedRelations.size())) << "% of relations have a changed member list" << std::endl;
 
         if (_createdNodes.empty() && _modifiedNodes.empty() &&
             _modifiedNodesWithChangedLocation.empty() && _deletedNodes.empty() &&

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -792,7 +792,7 @@ namespace olu::osm {
         }
     }
 
-    std::vector<Triple> OsmChangeHandler::filterRelevantTriples() {
+    std::vector<triple_t> OsmChangeHandler::filterRelevantTriples() {
         std::set<id_t> nodesToInsert;
         nodesToInsert.insert(_createdNodes.begin(), _createdNodes.end());
         nodesToInsert.insert(_modifiedNodes.begin(), _modifiedNodes.end());
@@ -808,7 +808,7 @@ namespace olu::osm {
         relationsToInsert.insert(_modifiedRelsWithChangedMembers.begin(), _modifiedRelsWithChangedMembers.end());
 
         // Triples that should be inserted into the database
-        std::vector<Triple> relevantTriples;
+        std::vector<triple_t> relevantTriples;
         // current link object, for example member nodes or geometries
         std::string currentLink;
 

--- a/src/osm/OsmDataFetcher.cpp
+++ b/src/osm/OsmDataFetcher.cpp
@@ -48,7 +48,7 @@ namespace olu::osm {
         std::string seqNumberFormatted =
                 util::URLHelper::formatSequenceNumberForUrl(sequenceNumber);
         std::string stateFileName =
-                seqNumberFormatted + ".state.txt";
+                seqNumberFormatted + "." + cnst::PATH_TO_STATE_FILE;
 
         std::vector<std::string> pathSegments { };
         pathSegments.emplace_back(_config.changeFileDirUri);
@@ -69,7 +69,7 @@ namespace olu::osm {
         // Build url for state file
         std::vector<std::string> pathSegments { };
         pathSegments.emplace_back(_config.changeFileDirUri);
-        pathSegments.emplace_back("state.txt");
+        pathSegments.emplace_back(cnst::PATH_TO_STATE_FILE);
         const std::string url = util::URLHelper::buildUrl(pathSegments);
 
         // Get state file from osm server
@@ -112,19 +112,19 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_NODE_LOCATION);
 
         std::vector<Node> nodes;
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             id_t id;
             std::string locationAsWkt;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    auto uri = binding.second.get<std::string>("uri");
+                if (name == cnst::NAME_VALUE) {
+                    auto uri = binding.second.get<std::string>(cnst::XML_TAG_URI);
                     id = OsmObjectHelper::getIdFromUri(uri);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_LOCATION) {
-                    locationAsWkt = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_LOCATION) {
+                    locationAsWkt = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
             }
 
@@ -210,34 +210,34 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_RELATION_MEMBERS);
 
         std::vector<Relation> relations;
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             id_t relationId;
             std::string type;
             std::string memberUris;
             std::string memberRoles;
             std::string memberPositions;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    auto relUri = binding.second.get<std::string>("uri");
+                if (name == cnst::NAME_VALUE) {
+                    auto relUri = binding.second.get<std::string>(cnst::XML_TAG_URI);
                     relationId = OsmObjectHelper::getIdFromUri(relUri);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_TYPE) {
-                    type = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_TYPE) {
+                    type = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_URIS) {
-                    memberUris = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_IDS) {
+                    memberUris = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_ROLES) {
-                    memberRoles = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_ROLES) {
+                    memberRoles = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_POSITIONS) {
-                    memberPositions = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_POSS) {
+                    memberPositions = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
             }
 
@@ -260,12 +260,12 @@ namespace olu::osm {
                 id_t id = OsmObjectHelper::getIdFromUri(uri);
 
                 std::string osmTag;
-                if (uri.starts_with(cnst::OSM_NODE_URI)) {
-                    osmTag = cnst::NODE_TAG;
-                } else if (uri.starts_with(cnst::OSM_WAY_URI)) {
-                    osmTag = cnst::WAY_TAG;
-                } else if (uri.starts_with(cnst::OSM_REL_URI)) {
-                    osmTag = cnst::RELATION_TAG;
+                if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
+                    osmTag = cnst::XML_TAG_NODE;
+                } else if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
+                    osmTag = cnst::XML_TAG_WAY;
+                } else if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_REL)) {
+                    osmTag = cnst::XML_TAG_REL;
                 }
                 members.emplace(std::stoi(position), RelationMember(id, osmTag, role));
             }
@@ -286,24 +286,24 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_WAY_MEMBERS);
 
         std::vector<Way> ways;
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             id_t wayId;
             std::string nodeUris;
             std::string nodePositions;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    auto wayUri = binding.second.get<std::string>("uri");
+                if (name == cnst::NAME_VALUE) {
+                    auto wayUri = binding.second.get<std::string>(cnst::XML_TAG_URI);
                     wayId = OsmObjectHelper::getIdFromUri(wayUri);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_URIS) {
-                    nodeUris = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_IDS) {
+                    nodeUris = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_POSITIONS) {
-                    nodePositions = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_POSS) {
+                    nodePositions = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
             }
 
@@ -334,40 +334,41 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     void OsmDataFetcher::fetchWayInfos(Way &way) {
-        std::string subject = "osmway:" + std::to_string(way.getId());
+        const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_WAY,
+                                                           std::to_string(way.getId()));
         auto response = runQuery(
             _queryWriter.writeQueryForTagsAndMetaInfo(subject),
             cnst::PREFIXES_FOR_WAY_TAGS_AND_META_INFO);
 
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             std::string key; std::string value;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
-                if (name == cnst::QUERY_VARIABLE_TIMESTAMP) {
-                    way.setTimestamp(binding.second.get<std::string>("literal"));
+                if (name == cnst::NAME_TIMESTAMP) {
+                    way.setTimestamp(binding.second.get<std::string>(cnst::XML_TAG_LITERAL));
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_VERSION) {
-                    auto version = binding.second.get<version_t>("literal");
+                if (name == cnst::NAME_VERSION) {
+                    auto version = binding.second.get<version_t>(cnst::XML_TAG_LITERAL);
                     way.setVersion(version);
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_CHANGESET) {
-                    auto changeset = binding.second.get<changeset_id_t>("literal");
+                if (name == cnst::NAME_CHANGESET) {
+                    auto changeset = binding.second.get<changeset_id_t>(cnst::XML_TAG_LITERAL);
                     way.setChangesetId(changeset);
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_KEY) {
-                    auto uri = binding.second.get<std::string>("uri");
-                    key = uri.substr(cnst::OSM_TAG_KEY.length());
+                if (name == cnst::NAME_KEY) {
+                    auto uri = binding.second.get<std::string>(cnst::XML_TAG_URI);
+                    key = uri.substr(cnst::NAMESPACE_IRI_OSM_KEY.length());
                 }
 
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    value = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_VALUE) {
+                    value = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
             }
 
@@ -379,46 +380,47 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     void OsmDataFetcher::fetchRelationInfos(Relation &relation) {
-        std::string subject = "osmrel:" + std::to_string(relation.getId());
+        const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_REL,
+                                                           std::to_string(relation.getId()));
         auto response = runQuery(
             _queryWriter.writeQueryForTagsAndMetaInfo(subject),
             cnst::PREFIXES_FOR_RELATION_TAGS_AND_META_INFO);
 
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             std::string key; std::string value;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
 
-                if (name == cnst::QUERY_VARIABLE_TIMESTAMP) {
-                    relation.setTimestamp(binding.second.get<std::string>("literal"));
+                if (name == cnst::NAME_TIMESTAMP) {
+                    relation.setTimestamp(binding.second.get<std::string>(cnst::XML_TAG_LITERAL));
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_VERSION) {
-                    auto version = binding.second.get<version_t>("literal");
+                if (name == cnst::NAME_VERSION) {
+                    auto version = binding.second.get<version_t>(cnst::XML_TAG_LITERAL);
                     relation.setVersion(version);
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_CHANGESET) {
-                    auto changesetString = binding.second.get<changeset_id_t>("literal");
+                if (name == cnst::NAME_CHANGESET) {
+                    auto changesetString = binding.second.get<changeset_id_t>(cnst::XML_TAG_LITERAL);
                     relation.setChangesetId(changesetString);
                     continue;
                 }
 
-                if (name == cnst::QUERY_VARIABLE_KEY) {
-                    auto uri = binding.second.get<std::string>("uri");
-                    key = uri.substr(cnst::OSM_TAG_KEY.length());
+                if (name == cnst::NAME_KEY) {
+                    auto uri = binding.second.get<std::string>(cnst::XML_TAG_URI);
+                    key = uri.substr(cnst::NAMESPACE_IRI_OSM_KEY.length());
                 }
 
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    value = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_VALUE) {
+                    value = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                 }
             }
 
             // Type of relation is already fetched in an earlier step
-            if (!key.empty() && key != cnst::QUERY_VARIABLE_TYPE) {
+            if (!key.empty() && key != cnst::NAME_TYPE) {
                 relation.addTag(key, value);
             }
         }
@@ -431,8 +433,8 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_WAY_MEMBERS);
 
         std::vector<id_t> nodeIds;
-        for (const auto &result : response.get_child("sparql.results")) {
-            auto memberUri = result.second.get<std::string>("binding.uri");
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto memberUri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
             nodeIds.emplace_back(OsmObjectHelper::getIdFromUri(memberUri));
         }
 
@@ -447,25 +449,25 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_WAY_MEMBERS);
 
         std::vector<std::pair<id_t, member_ids_t>> waysWithMembers;
-        for (const auto &result : response.get_child("sparql.results")) {
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
             id_t wayId = 0;
             member_ids_t memberIds;
             std::vector<int32_t> memberPositions;
             for (const auto &binding : result.second.get_child("")) {
-                auto name = util::XmlReader::readAttribute<std::string>("<xmlattr>.name",
+                auto name = util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_NAME,
                                                                         binding.second);
-                if (name == cnst::QUERY_VARIABLE_VALUE) {
-                    auto wayUri = binding.second.get<std::string>("uri");
+                if (name == cnst::NAME_VALUE) {
+                    auto wayUri = binding.second.get<std::string>(cnst::XML_TAG_URI);
                     wayId = OsmObjectHelper::getIdFromUri(wayUri);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_URIS) {
-                    auto memberUris = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_IDS) {
+                    auto memberUris = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                     memberIds = extractMembers(memberUris);
                 }
 
-                if (name == cnst::QUERY_VARIABLE_MEMBER_POSITIONS) {
-                    auto positions = binding.second.get<std::string>("literal");
+                if (name == cnst::NAME_MEMBER_POSS) {
+                    auto positions = binding.second.get<std::string>(cnst::XML_TAG_LITERAL);
                     memberPositions = extractPositions(positions);
                 }
             }
@@ -496,13 +498,13 @@ namespace olu::osm {
 
         std::vector<id_t> nodeIds;
         std::vector<id_t> wayIds;
-        for (const auto &result : response.get_child("sparql.results")) {
-            auto memberUri = result.second.get<std::string>("binding.uri");
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto memberUri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
 
             id_t id = OsmObjectHelper::getIdFromUri(memberUri);
-            if (memberUri.starts_with(cnst::OSM_NODE_URI)) {
+            if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
                 nodeIds.emplace_back(id);
-            } else if (memberUri.starts_with(cnst::OSM_WAY_URI)) {
+            } else if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
                 wayIds.emplace_back(id);
             }
         }
@@ -517,8 +519,8 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_WAYS_REFERENCING_NODE);
 
         std::vector<id_t> memberSubjects;
-        for (const auto &result : response.get_child("sparql.results")) {
-            auto memberUri = result.second.get<std::string>("binding.uri");
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto memberUri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
             memberSubjects.emplace_back(OsmObjectHelper::getIdFromUri(memberUri));
         }
 
@@ -534,8 +536,8 @@ namespace olu::osm {
 
         std::vector<id_t> relationIds;
         for (const auto &result : response.get_child(
-                "sparql.results")) {
-            auto memberUri = result.second.get<std::string>("binding.uri");
+                cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto memberUri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
             relationIds.emplace_back(OsmObjectHelper::getIdFromUri(memberUri));
         }
 
@@ -549,8 +551,8 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_WAY);
 
         std::vector<id_t> relationIds;
-        for (const auto &result : response.get_child("sparql.results")) {
-            auto uri = result.second.get<std::string>("binding.uri");
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto uri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
             relationIds.emplace_back(OsmObjectHelper::getIdFromUri(uri));
         }
 
@@ -565,8 +567,8 @@ namespace olu::osm {
             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS);
 
         std::vector<id_t> refRelIds;
-        for (const auto &result : response.get_child("sparql.results")) {
-            auto uri = result.second.get<std::string>("binding.uri");
+        for (const auto &result : response.get_child(cnst::XML_PATH_SPARQL_RESULTS)) {
+            auto uri = result.second.get<std::string>(cnst::XML_PATH_BINDING_URI);
             refRelIds.emplace_back(OsmObjectHelper::getIdFromUri(uri));
         }
 

--- a/src/osm/OsmReplicationServerHelper.cpp
+++ b/src/osm/OsmReplicationServerHelper.cpp
@@ -1,0 +1,151 @@
+//
+// Created by Nicolas von Trott on 15.05.25.
+//
+
+#include "config/Constants.h"
+#include "osm/OsmReplicationServerHelper.h"
+#include "util/URLHelper.h"
+#include "util/HttpRequest.h"
+
+#include <vector>
+#include <boost/regex.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <iostream>
+#include <fstream>
+
+namespace cnst = olu::config::constants;
+namespace olu::osm {
+
+    // _____________________________________________________________________________________________
+    OsmDatabaseState
+    OsmReplicationServerHelper::fetchDatabaseStateFromUrl(const std::string &stateFilePath) const {
+        const std::string url = util::URLHelper::buildUrl({
+            _config.changeFileDirUri,
+            stateFilePath});
+
+        std::string response;
+        try {
+            // Fetch state file from replication server
+            response = util::HttpRequest(util::GET, url).perform();
+        } catch (const std::exception& e) {
+            if (std::string(e.what()).find("404") != std::string::npos) {
+                std::cerr << "The state file was not found on the replication server. Perhaps it is "
+                             "too long in the past?" << std::endl;
+            }
+
+            const std::string msg = "Exception while trying to fetch state file from url: " + url;
+            throw OsmReplicationServerHelperException(msg.c_str());
+        }
+
+        return extractStateFromStateFile(response);
+    }
+
+    // _____________________________________________________________________________________________
+    OsmDatabaseState
+    OsmReplicationServerHelper::fetchDatabaseStateForSeqNumber(int sequenceNumber) const {
+        const auto stateFileName =
+                util::URLHelper::formatSequenceNumberForUrl(sequenceNumber) + "." +
+                cnst::PATH_TO_STATE_FILE;
+        return fetchDatabaseStateFromUrl(stateFileName);
+    }
+
+    // _____________________________________________________________________________________________
+    OsmDatabaseState OsmReplicationServerHelper::fetchLatestDatabaseState() const {
+        return fetchDatabaseStateFromUrl(cnst::PATH_TO_STATE_FILE);
+    }
+
+    // _____________________________________________________________________________________________
+    std::string OsmReplicationServerHelper::fetchChangeFile(int &sequenceNumber) {
+        std::string diffFilename = util::URLHelper::formatSequenceNumberForUrl(sequenceNumber)
+                                   + cnst::OSM_CHANGE_FILE_EXTENSION
+                                   + cnst::GZIP_EXTENSION;
+        std::string url = util::URLHelper::buildUrl({
+            _config.changeFileDirUri,
+            diffFilename});
+
+        // Get change file from server and write to cache file.
+        std::string response;
+        try {
+            response = util::HttpRequest(util::GET, url).perform();
+        } catch (const std::exception& e) {
+            if (std::string(e.what()).find("404") != std::string::npos) {
+                std::cerr << "The change file is not found on the replication server" << std::endl;
+            }
+
+            const std::string msg = "Exception while trying to fetch change file for sequence "
+                                    "number " + sequenceNumber;
+            throw OsmReplicationServerHelperException(msg.c_str());
+        }
+
+        std::string fileName = cnst::PATH_TO_CHANGE_FILE_DIR
+                               + std::to_string(sequenceNumber)
+                               + cnst::OSM_CHANGE_FILE_EXTENSION
+                               + cnst::GZIP_EXTENSION;
+
+        std::ofstream outputFile;
+        outputFile.open(fileName);
+        outputFile << response;
+        outputFile.close();
+
+        return fileName;
+    }
+
+    // _____________________________________________________________________________________________
+    OsmDatabaseState
+    OsmReplicationServerHelper::fetchDatabaseStateForTimestamp(const std::string& timeStamp) const {
+        // We start with the latest state file on the replication server
+        OsmDatabaseState state = fetchLatestDatabaseState();
+        while (true) {
+            // We have found state file at which we have to start, if the timestamp from the state
+            // file is further in the past than the latest timestamp from the sparql endpoint. (We
+            // can lexigraphically compare timestamps because they are ISO-formatted
+            // YYYY-MM-DDTHH:MM:SS)
+            if (state.timeStamp <= timeStamp) {
+                return state;
+            }
+
+            auto sequenceNumber = state.sequenceNumber;
+            sequenceNumber--;
+
+            try {
+                // Try the next older database state next
+                state = fetchDatabaseStateForSeqNumber(sequenceNumber);
+            } catch (std::exception &e) {
+                std::cerr << e.what() << std::endl;
+                const std::string msg = "Exception while trying to determine database state "
+                                        "for timestamp: " + timeStamp;
+                throw OsmReplicationServerHelperException(msg.c_str());
+            }
+        }
+    }
+
+    // _____________________________________________________________________________________________
+    OsmDatabaseState
+    OsmReplicationServerHelper::extractStateFromStateFile(const std::string& stateFile) {
+        OsmDatabaseState state;
+        // The state file always contains the sequence number like "sequenceNumber=4290"
+        const boost::regex regexSeqNumber("sequenceNumber=(\\d+)");
+        if (boost::smatch matchSeqNumber;
+            regex_search(stateFile, matchSeqNumber, regexSeqNumber)) {
+            state.sequenceNumber = std::stoi(matchSeqNumber[1]);
+        } else {
+            const std::string msg = "Could not extract sequence number from state file: " +
+                                    stateFile;
+            throw OsmReplicationServerHelperException(msg.c_str());
+        }
+
+        // The state file always contains the timestamp like "timestamp=2025-01-04T21\:21\:15Z"
+        const boost::regex regexTimestamp(
+                R"(timestamp=([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}\\:[0-9]{2}\\:[0-9]{2}Z))");
+        if (boost::smatch matchTimestamp;
+            regex_search(stateFile, matchTimestamp, regexTimestamp)) {
+            state.timeStamp = matchTimestamp[1];
+        } else {
+            throw OsmReplicationServerHelperException(
+                    "Timestamp of latest database state could not be fetched");
+        }
+
+        return state;
+    }
+
+}

--- a/src/osm/OsmUpdater.cpp
+++ b/src/osm/OsmUpdater.cpp
@@ -25,7 +25,7 @@
 namespace cnst = olu::config::constants;
 namespace olu::osm {
     OsmUpdater::OsmUpdater(const config::Config &config) : _config(config), _odf(config),
-                                                          _latestState({}) {
+                                                          _latestState({}), _repServer(config) {
         try {
             std::filesystem::create_directory(cnst::PATH_TO_TEMP_DIR);
             std::filesystem::create_directory(cnst::PATH_TO_CHANGE_FILE_DIR);
@@ -67,7 +67,7 @@ namespace olu::osm {
             << "Determine sequence number to start with ..."
             << std::endl;
 
-            _latestState = _odf.fetchLatestDatabaseState();
+            _latestState = _repServer.fetchLatestDatabaseState();
             const auto sequenceNumber = decideStartSequenceNumber();
 
             std::cout
@@ -123,7 +123,7 @@ namespace olu::osm {
             timestamp = _config.timestamp;
         }
 
-        auto [_, sequenceNumber] = _odf.fetchDatabaseStateForTimestamp(timestamp);
+        auto [_, sequenceNumber] = _repServer.fetchDatabaseStateForTimestamp(timestamp);
         return sequenceNumber;
     }
 
@@ -192,7 +192,7 @@ namespace olu::osm {
         downloadProgress.update(counter);
 
         while (sequenceNumber <= _latestState.sequenceNumber) {
-            auto pathToOsmChangeFile = _odf.fetchChangeFile(sequenceNumber);
+            auto pathToOsmChangeFile = _repServer.fetchChangeFile(sequenceNumber);
             downloadProgress.update(counter++);
             sequenceNumber++;
         }

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -74,7 +74,8 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
 
 // _________________________________________________________________________________________________
 std::string
-olu::sparql::QueryWriter::writeDeleteQueryForMetaAndTags(const std::set<id_t> &ids, const std::string &osmTag) const {
+olu::sparql::QueryWriter::writeDeleteQueryForMetaAndTags(const std::set<id_t> &ids,
+                                                         const std::string &osmTag) const {
     std::ostringstream oss;
     oss << "DELETE { ";
     oss << wrapWithGraphOptional(
@@ -84,6 +85,33 @@ olu::sparql::QueryWriter::writeDeleteQueryForMetaAndTags(const std::set<id_t> &i
         getValuesClause(osmTag + ":", ids) +
         getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "?p", "?o") +
         "FILTER (STRSTARTS(STR(?p),STR(osmmeta:)) || STRSTARTS(STR(?p),STR(osmkey:)) || STRSTARTS(STR(?p),STR(osm2rdf:facts))) .  }");
+    return oss.str();
+}
+
+
+// _________________________________________________________________________________________________
+std::string
+olu::sparql::QueryWriter::writeDeleteQueryForGeometry(const std::set<id_t> &ids,
+                                                      const std::string &osmTag) const {
+    std::ostringstream oss;
+    oss << "DELETE { ";
+    oss << wrapWithGraphOptional(
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdfgeom:obb", "?o1") +
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdfgeom:envelope", "?o2") +
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdfgeom:convex_hull", "?o3") +
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdf:length", "?o4") +
+        getTripleClause("?geom", "geo:asWKT", "?o5") +
+        getTripleClause("?cent", "geo:asWKT", "?o6"));
+    oss << "} WHERE { ";
+    oss << wrapWithGraphOptional(
+        getValuesClause(osmTag + ":", ids) +
+        "OPTIONAL { ?value osm2rdfgeom:obb ?o1 . } "
+        "OPTIONAL { ?value osm2rdfgeom:envelope ?o2 . } "
+        "OPTIONAL { ?value osm2rdfgeom:convex_hull ?o3 . } "
+        "OPTIONAL { ?value osm2rdf:length ?o4 . } "
+        "OPTIONAL { ?value geo:hasGeometry ?geom . ?geom geo:asWKT ?o5 . } "
+        "OPTIONAL { ?value geo:hasCentroid ?cent . ?cent geo:asWKT ?o6 . } ");
+    oss << " }";
     return oss.str();
 }
 

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -71,6 +71,22 @@ olu::sparql::QueryWriter::writeDeleteQuery(const std::set<id_t> &ids, const std:
     oss << " }";
     return oss.str();
 }
+
+// _________________________________________________________________________________________________
+std::string
+olu::sparql::QueryWriter::writeDeleteQueryForMetaAndTags(const std::set<id_t> &ids, const std::string &osmTag) const {
+    std::ostringstream oss;
+    oss << "DELETE { ";
+    oss << wrapWithGraphOptional(
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "?p", "?o"));
+    oss << "} WHERE { ";
+    oss << wrapWithGraphOptional(
+        getValuesClause(osmTag + ":", ids) +
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "?p", "?o") +
+        "FILTER (STRSTARTS(STR(?p),STR(osmmeta:)) || STRSTARTS(STR(?p),STR(osmkey:)) || STRSTARTS(STR(?p),STR(osm2rdf:facts))) .  }");
+    return oss.str();
+}
+
 // _________________________________________________________________________________________________
 std::string
 olu::sparql::QueryWriter::writeQueryForNodeLocations(const std::set<id_t> &nodeIds) const {

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -100,8 +100,9 @@ olu::sparql::QueryWriter::writeDeleteQueryForGeometry(const std::set<id_t> &ids,
         getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdfgeom:envelope", "?o2") +
         getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdfgeom:convex_hull", "?o3") +
         getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdf:length", "?o4") +
-        getTripleClause("?geom", "geo:asWKT", "?o5") +
-        getTripleClause("?cent", "geo:asWKT", "?o6"));
+        getTripleClause("?" + cnst::QUERY_VARIABLE_VALUE, "osm2rdf:area", "?o5") +
+        getTripleClause("?geom", "geo:asWKT", "?o6") +
+        getTripleClause("?cent", "geo:asWKT", "?o7"));
     oss << "} WHERE { ";
     oss << wrapWithGraphOptional(
         getValuesClause(osmTag + ":", ids) +
@@ -109,8 +110,9 @@ olu::sparql::QueryWriter::writeDeleteQueryForGeometry(const std::set<id_t> &ids,
         "OPTIONAL { ?value osm2rdfgeom:envelope ?o2 . } "
         "OPTIONAL { ?value osm2rdfgeom:convex_hull ?o3 . } "
         "OPTIONAL { ?value osm2rdf:length ?o4 . } "
-        "OPTIONAL { ?value geo:hasGeometry ?geom . ?geom geo:asWKT ?o5 . } "
-        "OPTIONAL { ?value geo:hasCentroid ?cent . ?cent geo:asWKT ?o6 . } ");
+        "OPTIONAL { ?value osm2rdf:area ?o5 . } "
+        "OPTIONAL { ?value geo:hasGeometry ?geom . ?geom geo:asWKT ?o6 . } "
+        "OPTIONAL { ?value geo:hasCentroid ?cent . ?cent geo:asWKT ?o7 . } ");
     oss << " }";
     return oss.str();
 }

--- a/src/util/OsmObjectHelper.cpp
+++ b/src/util/OsmObjectHelper.cpp
@@ -7,13 +7,15 @@
 
 #include <iostream>
 #include <string>
+#include <config/Constants.h>
 
+namespace cnst = olu::config::constants;
 namespace olu::osm {
     bool OsmObjectHelper::isMultipolygon(const boost::property_tree::ptree &relation) {
         for (const auto &[tag, attr]: relation.get_child("")) {
-            if (tag == "tag") {
-                if (util::XmlReader::readAttribute<std::string>("<xmlattr>.k", attr) == "type" &&
-                    util::XmlReader::readAttribute<std::string>("<xmlattr>.v", attr) == "multipolygon") {
+            if (tag == cnst::XML_TAG_TAG) {
+                if (util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_KEY, attr) == "type" &&
+                    util::XmlReader::readAttribute<std::string>(cnst::XML_PATH_ATTR_VALUE, attr) == "multipolygon") {
                     return true;
                     }
             }

--- a/src/util/OsmObjectHelper.cpp
+++ b/src/util/OsmObjectHelper.cpp
@@ -12,8 +12,8 @@ namespace olu::osm {
     bool OsmObjectHelper::isMultipolygon(const boost::property_tree::ptree &relation) {
         for (const auto &[tag, attr]: relation.get_child("")) {
             if (tag == "tag") {
-                if (util::XmlReader::readAttribute("<xmlattr>.k", attr) == "type" &&
-                    util::XmlReader::readAttribute("<xmlattr>.v", attr) == "multipolygon") {
+                if (util::XmlReader::readAttribute<std::string>("<xmlattr>.k", attr) == "type" &&
+                    util::XmlReader::readAttribute<std::string>("<xmlattr>.v", attr) == "multipolygon") {
                     return true;
                     }
             }
@@ -41,6 +41,12 @@ namespace olu::osm {
             throw OsmObjectHelperException(msg.c_str());
         }
     }
+
+    bool OsmObjectHelper::areMemberEqual(member_ids_t member1, member_ids_t member2) {
+        return member1.size() == member2.size() &&
+            std::equal(member1.begin(), member1.end(), member2.begin());
+    }
+
 }
 
 

--- a/src/util/OsmObjectHelper.cpp
+++ b/src/util/OsmObjectHelper.cpp
@@ -44,11 +44,37 @@ namespace olu::osm {
         }
     }
 
-    bool OsmObjectHelper::areMemberEqual(member_ids_t member1, member_ids_t member2) {
+    std::string OsmObjectHelper::getOsmTagFromUri(const std::string& uri) {
+        if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
+            return cnst::XML_TAG_NODE;
+        }
+
+        if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
+            return cnst::XML_TAG_WAY;
+        }
+
+        if (uri.starts_with(cnst::NAMESPACE_IRI_OSM_REL)) {
+            return cnst::XML_TAG_REL;
+        }
+
+        const std::string msg = "Cant extract osm tag from uri: " + uri;
+        throw OsmObjectHelperException(msg.c_str());
+    }
+
+    bool OsmObjectHelper::areWayMemberEqual(member_ids_t member1, member_ids_t member2) {
         return member1.size() == member2.size() &&
             std::equal(member1.begin(), member1.end(), member2.begin());
     }
 
+    bool OsmObjectHelper::areRelMemberEqual(rel_members_t member1, rel_members_t member2) {
+        return member1.size() == member2.size() &&
+            std::equal(member1.begin(), member1.end(), member2.begin(),
+                     [](const RelationMember& a, const RelationMember& b) {
+                         return a.id == b.id &&
+                                a.osmTag == b.osmTag &&
+                                a.role == b.role;
+                     });
+    }
 }
 
 

--- a/src/util/TtlHelper.cpp
+++ b/src/util/TtlHelper.cpp
@@ -10,7 +10,7 @@
 namespace cnst = olu::config::constants;
 namespace olu::util {
 
-    Triple TtlHelper::getTriple(const std::string& triple) {
+    triple_t TtlHelper::getTriple(const std::string& triple) {
         const boost::regex regex(R"((\S+)\s(\S+)\s(.*)\s\.)");
         if (boost::smatch match; boost::regex_search(triple, match, regex)) {
             return std::make_tuple(match[1], match[2], match[3]);

--- a/src/util/TtlHelper.cpp
+++ b/src/util/TtlHelper.cpp
@@ -50,7 +50,7 @@ namespace olu::util {
         }
 
         if (osmTag == cnst::XML_TAG_REL) {
-            return predicate == cnst::PREFIXED_RELATION_MEMBER ||
+            return predicate == cnst::PREFIXED_REL_MEMBER ||
                    predicate == cnst::PREFIXED_GEO_HAS_CENTROID ||
                    predicate == cnst::PREFIXED_GEO_HAS_GEOMETRY;
         }

--- a/src/util/TtlHelper.cpp
+++ b/src/util/TtlHelper.cpp
@@ -21,16 +21,16 @@ namespace olu::util {
     }
 
     bool TtlHelper::isRelevantNamespace(const std::string& subject, const std::string &osmTag) {
-        if (osmTag == cnst::NODE_TAG) {
-            return subject.starts_with("osmnode:");
+        if (osmTag == cnst::XML_TAG_NODE) {
+            return subject.starts_with(cnst::NAMESPACE_OSM_NODE);
         }
 
-        if (osmTag == cnst::WAY_TAG) {
-            return subject.starts_with("osmway:");
+        if (osmTag == cnst::XML_TAG_WAY) {
+            return subject.starts_with(cnst::NAMESPACE_OSM_WAY);
         }
 
-        if (osmTag == cnst::RELATION_TAG) {
-            return subject.starts_with("osmrel:");
+        if (osmTag == cnst::XML_TAG_REL) {
+            return subject.starts_with(cnst::NAMESPACE_OSM_REL);
         }
 
         const std::string msg = "Cant interpret subject: " + subject;
@@ -38,21 +38,21 @@ namespace olu::util {
     }
 
     bool TtlHelper::hasRelevantObject(const std::string& predicate, const std::string &osmTag) {
-        if (osmTag == cnst::NODE_TAG) {
-            return predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
-                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
+        if (osmTag == cnst::XML_TAG_NODE) {
+            return predicate == cnst::PREFIXED_GEO_HAS_CENTROID ||
+                   predicate == cnst::PREFIXED_GEO_HAS_GEOMETRY;
         }
 
-        if (osmTag == cnst::WAY_TAG) {
-            return predicate == cnst::OSM_2_RDF_WAY_MEMBER ||
-                   predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
-                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
+        if (osmTag == cnst::XML_TAG_WAY) {
+            return predicate == cnst::PREFIXED_WAY_MEMBER ||
+                   predicate == cnst::PREFIXED_GEO_HAS_CENTROID ||
+                   predicate == cnst::PREFIXED_GEO_HAS_GEOMETRY;
         }
 
-        if (osmTag == cnst::RELATION_TAG) {
-            return predicate == cnst::OSM_2_RDF_RELATION_MEMBER ||
-                   predicate == cnst::OSM_2_RDF_GEO_HAS_CENTROID ||
-                   predicate == cnst::OSM_2_RDF_GEO_HAS_GEOMETRY;
+        if (osmTag == cnst::XML_TAG_REL) {
+            return predicate == cnst::PREFIXED_RELATION_MEMBER ||
+                   predicate == cnst::PREFIXED_GEO_HAS_CENTROID ||
+                   predicate == cnst::PREFIXED_GEO_HAS_GEOMETRY;
         }
 
         const std::string msg = "Cant interpret predicate: " + predicate;
@@ -61,11 +61,11 @@ namespace olu::util {
 
     id_t TtlHelper::getIdFromSubject(const std::string& subject, const std::string& osmTag) {
         std::string regexString;
-        if (osmTag == cnst::NODE_TAG) {
+        if (osmTag == cnst::XML_TAG_NODE) {
             regexString = R"((?:osmnode:|osm_node_|osm_node_centroid_)(\d+))";
-        } else if (osmTag == cnst::WAY_TAG) {
+        } else if (osmTag == cnst::XML_TAG_WAY) {
             regexString = R"((?:osmway:|osm_wayarea_)(\d+))";
-        } else if (osmTag == cnst::RELATION_TAG) {
+        } else if (osmTag == cnst::XML_TAG_REL) {
             regexString = R"((?:osmrel:|osm_relarea_)(\d+))";
         } else {
             const std::string msg = "Unknown element tag: " + osmTag;

--- a/src/util/URLHelper.cpp
+++ b/src/util/URLHelper.cpp
@@ -40,7 +40,7 @@ namespace constants = olu::config::constants;
 namespace olu::util {
 
 // _________________________________________________________________________________________________
-std::string URLHelper::buildUrl(std::vector<std::string> &pathSegments) {
+std::string URLHelper::buildUrl(const std::vector<std::string> &pathSegments) {
     std::string url;
     for( const auto& segment : pathSegments ) {
         if(&segment == &pathSegments.back() ) {

--- a/src/util/XmlReader.cpp
+++ b/src/util/XmlReader.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 
 namespace pt = boost::property_tree;
+namespace cnst = olu::config::constants;
 
 // _________________________________________________________________________________________________
 void olu::util::XmlReader::populatePTreeFromString(const std::string &xml, pt::ptree &tree) {
@@ -80,7 +81,7 @@ std::vector<std::string> olu::util::XmlReader::readTagOfChildren(
 
     std::vector<std::string> childrenNames;
     for (const auto &child : tree.get_child(parentPath)) {
-        if (excludeXmlAttr && child.first == olu::config::constants::XML_ATTRIBUTE_TAG) {
+        if (excludeXmlAttr && child.first == olu::config::constants::XML_TAG_ATTR) {
             continue;
         }
 
@@ -93,12 +94,12 @@ std::vector<std::string> olu::util::XmlReader::readTagOfChildren(
 // _________________________________________________________________________________________________
 void olu::util::XmlReader::sanitizeXmlTags(pt::ptree &tree) {
     for (auto &tag : tree.get_child("")) {
-        if (tag.first == "tag") {
-            auto value = tag.second.get<std::string>("<xmlattr>.v");
+        if (tag.first == cnst::XML_TAG_TAG) {
+            auto value = tag.second.get<std::string>(cnst::XML_PATH_ATTR_VALUE);
             if (isXmlEncoded(value)) {
                 value = xmlEncode(value);
             }
-            tag.second.put<std::string>("<xmlattr>.v", value);
+            tag.second.put<std::string>(cnst::XML_PATH_ATTR_VALUE, value);
         }
     }
 }

--- a/src/util/XmlReader.cpp
+++ b/src/util/XmlReader.cpp
@@ -72,34 +72,6 @@ std::string olu::util::XmlReader::readTree(const pt::ptree &tree,
     return oss.str();
 }
 
-// _____________________________________________________________________________________________
-std::string
-olu::util::XmlReader::readAttribute(const std::string& attributePath,
-                                    const boost::property_tree::ptree& tree) {
-    std::string attributeValue;
-    try {
-        attributeValue = tree.get<std::string>(attributePath);
-    } catch (boost::property_tree::ptree_bad_path &e) {
-        std::cerr << "Path not found: " << e.what() << std::endl;
-        std::string msg = "Exception while trying to read attribute at path: " + attributePath;
-        throw XmlReaderException(msg.c_str());
-    } catch (boost::property_tree::ptree_bad_data &e) {
-        std::cerr << "Bad data: " << e.what() << std::endl;
-        std::string msg = "Exception while trying to read attribute at path: " + attributePath;
-        throw XmlReaderException(msg.c_str());
-    } catch (boost::property_tree::ptree_error &e) {
-        std::cerr << "Property tree error: " << e.what() << std::endl;
-        std::string msg = "Exception while trying to read attribute at path: " + attributePath;
-        throw XmlReaderException(msg.c_str());
-    } catch (std::exception &e) {
-        std::cerr << e.what() << std::endl;
-        std::string msg = "Exception while trying to read attribute at path: " + attributePath;
-        throw XmlReaderException(msg.c_str());
-    }
-
-    return attributeValue;
-}
-
 // _________________________________________________________________________________________________
 std::vector<std::string> olu::util::XmlReader::readTagOfChildren(
         const std::string &parentPath,

--- a/tests/sparql/QueryWriter.cpp
+++ b/tests/sparql/QueryWriter.cpp
@@ -119,7 +119,7 @@ namespace olu::sparql {
     TEST(QueryWriter, writeQueryForRelationMembersWay) {
         {
             QueryWriter qw{config::Config()};
-            std::string query = qw.writeQueryForRelationMembers({1, 2, 3});
+            std::string query = qw.writeQueryForRelationMemberIds({1, 2, 3});
             ASSERT_EQ(
                     "SELECT ?p WHERE { "
                     "VALUES ?rel { osmrel:1 osmrel:2 osmrel:3 } "

--- a/tests/util/XmlReader.cpp
+++ b/tests/util/XmlReader.cpp
@@ -33,7 +33,7 @@ TEST(XmlReader, readAttribute) {
         pt::ptree tree;
         olu::util::XmlReader::populatePTreeFromString(content, tree);
 
-        std::string attribute = olu::util::XmlReader::readAttribute(
+        auto attribute = olu::util::XmlReader::readAttribute<std::string>(
                 "osm.node.<xmlattr>.id",
                 tree);
         ASSERT_EQ(attribute, "1");
@@ -51,7 +51,7 @@ TEST(XmlReader, readAttribute) {
         pt::ptree tree;
         olu::util::XmlReader::populatePTreeFromString(content, tree);
 
-        EXPECT_ANY_THROW(olu::util::XmlReader::readAttribute("osm.node.<xmlattr>.notExisting", tree));
+        EXPECT_ANY_THROW(olu::util::XmlReader::readAttribute<std::string>("osm.node.<xmlattr>.notExisting", tree));
 
         tree.clear();
     }

--- a/tests/util/XmlReader.cpp
+++ b/tests/util/XmlReader.cpp
@@ -70,21 +70,21 @@ TEST(XmlReader, readTagOfChildren) {
         olu::util::XmlReader::populatePTreeFromString(content, tree);
 
         auto childrenTags = olu::util::XmlReader::readTagOfChildren(
-                olu::config::constants::OSM_TAG,
+                olu::config::constants::XML_TAG_OSM,
                 tree,
                 false);
 
         ASSERT_EQ(childrenTags.size(), 2);
-        ASSERT_EQ(childrenTags.at(0), olu::config::constants::XML_ATTRIBUTE_TAG);
-        ASSERT_EQ(childrenTags.at(1), olu::config::constants::NODE_TAG);
+        ASSERT_EQ(childrenTags.at(0), olu::config::constants::XML_TAG_ATTR);
+        ASSERT_EQ(childrenTags.at(1), olu::config::constants::XML_TAG_NODE);
 
         auto childrenTags2 = olu::util::XmlReader::readTagOfChildren(
-                olu::config::constants::OSM_TAG,
+                olu::config::constants::XML_TAG_OSM,
                 tree,
                 true);
 
         ASSERT_EQ(childrenTags2.size(), 1);
-        ASSERT_EQ(childrenTags2.at(0), olu::config::constants::NODE_TAG);
+        ASSERT_EQ(childrenTags2.at(0), olu::config::constants::XML_TAG_NODE);
 
         tree.clear();
     }


### PR DESCRIPTION
Continuation of Pull Request [Reduce number of updated triples](https://github.com/ad-freiburg/osm-live-updates/pull/25).

Reduce the number of updated triples further by:

- Check for ways and relations that appear in a modify tag inside the change file if their members have changed and update their membership triples only if this is the case
- Update only the geometry triples for ways and relations that reference a osm object from the change file with a changed location, or changed members