### PR TITLE
Improved communication with QLever endpoints and added more extensive statistics

### DIFF
--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -33,7 +33,7 @@ enum SparqlOutput {
 struct Config {
     static constexpr u_int16_t DEFAULT_WKT_PRECISION = 7;
     static constexpr u_int16_t DEFAULT_PERCENTAGE_PRECISION = 1;
-    static constexpr u_int32_t DEFAULT_BATCH_SIZE = 1024;
+    static constexpr u_int32_t DEFAULT_BATCH_SIZE = 1 << 19;
 
     // The uri of the SPARQL endpoint for queries
     std::string sparqlEndpointUri;

--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -32,6 +32,7 @@ enum SparqlOutput {
 
 struct Config {
     static constexpr u_int16_t DEFAULT_WKT_PRECISION = 7;
+    static constexpr u_int16_t DEFAULT_PERCENTAGE_PRECISION = 1;
     static constexpr u_int32_t DEFAULT_BATCH_SIZE = 1024;
 
     // The uri of the SPARQL endpoint for queries
@@ -63,6 +64,9 @@ struct Config {
 
     // Option that can be used if the SPARQL endpoint is QLever.
     bool isQLever = false;
+
+    // Option to enable detailed statistics output.
+    bool showDetailedStatistics = false;
 
     // The number of values or triples that should be sent in one batch to the SPARQL endpoint
     size_t batchSize = DEFAULT_BATCH_SIZE;

--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -61,6 +61,9 @@ struct Config {
     // Specifies whether a progress bar should be shown
     bool showProgress = true;
 
+    // Option that can be used if the SPARQL endpoint is QLever.
+    bool isQLever = false;
+
     // The number of values or triples that should be sent in one batch to the SPARQL endpoint
     size_t batchSize = DEFAULT_BATCH_SIZE;
 

--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <filesystem>
+#include <thread>
 
 namespace olu::config {
 
@@ -55,6 +56,8 @@ struct Config {
     int sequenceNumber = -1;
     // User specified timestamp from command line
     std::string timestamp;
+
+    int numThreads = std::thread::hardware_concurrency();
 
     // Specifies if osm2rdf should be run with the option to mask blank nodes
     bool noBlankNodes = false;

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -62,6 +62,11 @@ namespace olu::config::constants {
     const static inline std::string PATH_TO_OSM2RDF_INFO_OUTPUT_FILE_DEBUG = "osm2rdf_info" + TEXT_FILE_EXTENSION;
     const static inline std::string PATH_TO_STATE_FILE = "state" + TEXT_FILE_EXTENSION;
 
+    // LOG -----------------------------------------------------------------------------------------
+    const static inline std::string LOG_WARNING = "WARNING:";
+    const static inline std::string LOG_ERROR = "ERROR:";
+    const static inline std::string LOG_INFO = "INFO:";
+
     // XML -----------------------------------------------------------------------------------------
     const static inline std::string XML_TAG_ATTR = "<xmlattr>";
     const static inline std::string XML_TAG_NODE = "node";
@@ -88,6 +93,10 @@ namespace olu::config::constants {
     const static inline std::string KEY_QLEVER_TIME = "time";
     const static inline std::string KEY_QLEVER_TOTAL = "total";
     const static inline std::string KEY_QLEVER_COMPUTE_RESULT = "computeResult";
+    const static inline std::string KEY_QLEVER_DELTA_TRIPLES = "delta-triples";
+    const static inline std::string KEY_QLEVER_DIFFERENCE = "difference";
+    const static inline std::string KEY_QLEVER_DELETED = "deleted";
+    const static inline std::string KEY_QLEVER_INSERTED = "inserted";
     const static inline std::string KEY_VALUE = "value";
 
     const static inline std::string XML_TAG_NAME = "name";

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -34,10 +34,10 @@ namespace olu::config::constants {
     const static inline std::string HTML_VALUE_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
     const static inline std::string HTML_KEY_ACCEPT = "Accept";
-    const static inline std::string HTML_VALUE_ACCEPT_SPARQL_RESULT_XML =
-            "application/sparql-results+xml";
     const static inline std::string HTML_VALUE_ACCEPT_SPARQL_RESULT_JSON =
             "application/sparql-results+json";
+    const static inline std::string HTML_VALUE_ACCEPT_QLEVER_RESULT_JSON =
+            "application/qlever-results+json";
 
     // File extensions -----------------------------------------------------------------------------
     const static inline std::string OSM_CHANGE_FILE_EXTENSION = ".osc";
@@ -83,6 +83,8 @@ namespace olu::config::constants {
     const static inline std::string XML_TAG_SPARQL = "sparql";
     const static inline std::string KEY_RESULTS = "results";
     const static inline std::string KEY_BINDINGS = "bindings";
+    const static inline std::string KEY_QLEVER_SELECTED = "selected";
+    const static inline std::string KEY_QLEVER_RESULTS = "res";
     const static inline std::string KEY_VALUE = "value";
 
     const static inline std::string XML_TAG_NAME = "name";
@@ -422,6 +424,12 @@ namespace olu::config::constants {
     const static inline std::string BATCH_SIZE_OPTION_HELP =
         "The number of values or triples that should be sent in one batch to the SPARQL endpoint. "
         "Default is " + std::to_string(Config::DEFAULT_BATCH_SIZE) + ".";
+
+    const static inline std::string QLEVER_ENDPOINT_INFO = "Working with a QLever endpoint";
+    const static inline std::string QLEVER_ENDPOINT_OPTION_SHORT = "";
+    const static inline std::string QLEVER_ENDPOINT_OPTION_LONG = "qlever";
+    const static inline std::string QLEVER_ENDPOINT_OPTION_HELP =
+        "Specify if the SPARQL endpoint is QLever. More metadata will be added to the output.";
 
 } // namespace olu::config::constants
 

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -431,6 +431,12 @@ namespace olu::config::constants {
     const static inline std::string QLEVER_ENDPOINT_OPTION_HELP =
         "Specify if the SPARQL endpoint is QLever. More metadata will be added to the output.";
 
+    const static inline std::string STATISTICS_INFO = "";
+    const static inline std::string STATISTICS_OPTION_SHORT = "";
+    const static inline std::string STATISTICS_OPTION_LONG = "statistics";
+    const static inline std::string STATISTICS_OPTION_HELP =
+        "Specify if detailed statistics should be added to the output.";
+
 } // namespace olu::config::constants
 
 #endif //OSM_LIVE_UPDATES_CONSTANTS_H

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -85,6 +85,9 @@ namespace olu::config::constants {
     const static inline std::string KEY_BINDINGS = "bindings";
     const static inline std::string KEY_QLEVER_SELECTED = "selected";
     const static inline std::string KEY_QLEVER_RESULTS = "res";
+    const static inline std::string KEY_QLEVER_TIME = "time";
+    const static inline std::string KEY_QLEVER_TOTAL = "total";
+    const static inline std::string KEY_QLEVER_COMPUTE_RESULT = "computeResult";
     const static inline std::string KEY_VALUE = "value";
 
     const static inline std::string XML_TAG_NAME = "name";

--- a/include/osm/Node.h
+++ b/include/osm/Node.h
@@ -45,6 +45,13 @@ namespace olu::osm {
     protected:
         id_t id;
         osmium::Location loc;
+
+        /**
+         * Parses a WKT point string with prefix
+         * ("\"POINT(1.622847 42.525981)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>")
+         * and returns the POINT part.
+         */
+        static std::string parseWktPoint(const std::string& wktPoint);
     };
 
     /**

--- a/include/osm/NodeHandler.h
+++ b/include/osm/NodeHandler.h
@@ -30,7 +30,7 @@ namespace olu::osm {
 
     class NodeHandler: public osmium::handler::Handler {
     public:
-        explicit NodeHandler(const config::Config &config): _config(config), _odf(config) {}
+        explicit NodeHandler(const config::Config &config, OsmDataFetcher &odf): _config(config), _odf(&odf) {}
 
         // Iterator for osmium::apply
         void node(const osmium::Node& node);
@@ -95,7 +95,7 @@ namespace olu::osm {
 
     private:
         config::Config _config;
-        OsmDataFetcher _odf;
+        OsmDataFetcher* _odf;
 
         // Nodes that are in a delete-changeset in the change file.
         std::set<id_t> _deletedNodes;

--- a/include/osm/NodeHandler.h
+++ b/include/osm/NodeHandler.h
@@ -25,12 +25,15 @@
 #include "osmium/handler.hpp"
 
 #include "OsmDataFetcher.h"
+#include "StatisticsHandler.h"
 
 namespace olu::osm {
 
     class NodeHandler: public osmium::handler::Handler {
     public:
-        explicit NodeHandler(const config::Config &config, OsmDataFetcher &odf): _config(config), _odf(&odf) {}
+        explicit NodeHandler(const config::Config &config, OsmDataFetcher &odf,
+                             StatisticsHandler &stats): _config(config), _odf(&odf),
+                                                        _stats(&stats) { }
 
         // Iterator for osmium::apply
         void node(const osmium::Node& node);
@@ -64,11 +67,6 @@ namespace olu::osm {
         }
 
         /**
-         * Prints the number of created, modified and deleted nodes to the console.
-         */
-        void printNodeStatistics() const;
-
-        /**
          * @return True if the change file contains no nodes.
          */
         bool empty() const {
@@ -96,6 +94,7 @@ namespace olu::osm {
     private:
         config::Config _config;
         OsmDataFetcher* _odf;
+        StatisticsHandler* _stats;
 
         // Nodes that are in a delete-changeset in the change file.
         std::set<id_t> _deletedNodes;

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -22,6 +22,7 @@
 #include <set>
 #include <sparql/QueryWriter.h>
 
+#include "StatisticsHandler.h"
 #include "osmium/handler.hpp"
 #include "osm2rdf/util/ProgressBar.h"
 
@@ -46,13 +47,15 @@ namespace olu::osm {
      */
     class OsmChangeHandler: public osmium::handler::Handler {
     public:
-        explicit OsmChangeHandler(const config::Config &config, OsmDataFetcher &odf);
+        explicit OsmChangeHandler(const config::Config &config, OsmDataFetcher &odf,
+                                  StatisticsHandler &stats);
         void run();
     private:
         config::Config _config;
         sparql::SparqlWrapper _sparql;
         sparql::QueryWriter _queryWriter;
         OsmDataFetcher* _odf;
+        StatisticsHandler* _stats;
 
         /**
          * Osmium handler for the nodes in the change file.

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -20,9 +20,8 @@
 #define OSM_LIVE_UPDATES_OSMCHANGEHANDLER_H
 
 #include <set>
-#include <sparql/QueryWriter.h>
 
-#include "StatisticsHandler.h"
+#include "simdjson.h"
 #include "osmium/handler.hpp"
 #include "osm2rdf/util/ProgressBar.h"
 
@@ -33,6 +32,8 @@
 #include "osm/RelationHandler.h"
 #include "osm/WayHandler.h"
 #include "sparql/SparqlWrapper.h"
+#include "sparql/QueryWriter.h"
+#include "osm/StatisticsHandler.h"
 
 namespace olu::osm {
     /**
@@ -56,6 +57,7 @@ namespace olu::osm {
         sparql::QueryWriter _queryWriter;
         OsmDataFetcher* _odf;
         StatisticsHandler* _stats;
+        simdjson::ondemand::parser _parser;
 
         /**
          * Osmium handler for the nodes in the change file.

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -21,7 +21,6 @@
 
 #include <set>
 
-#include "simdjson.h"
 #include "osmium/handler.hpp"
 #include "osm2rdf/util/ProgressBar.h"
 
@@ -57,7 +56,6 @@ namespace olu::osm {
         sparql::QueryWriter _queryWriter;
         OsmDataFetcher* _odf;
         StatisticsHandler* _stats;
-        simdjson::ondemand::parser _parser;
 
         /**
          * Osmium handler for the nodes in the change file.

--- a/include/osm/OsmChangeHandler.h
+++ b/include/osm/OsmChangeHandler.h
@@ -20,6 +20,7 @@
 #define OSM_LIVE_UPDATES_OSMCHANGEHANDLER_H
 
 #include <set>
+#include <sparql/QueryWriter.h>
 
 #include "osmium/handler.hpp"
 #include "osm2rdf/util/ProgressBar.h"
@@ -45,13 +46,13 @@ namespace olu::osm {
      */
     class OsmChangeHandler: public osmium::handler::Handler {
     public:
-        explicit OsmChangeHandler(const config::Config &config);
+        explicit OsmChangeHandler(const config::Config &config, OsmDataFetcher &odf);
         void run();
     private:
         config::Config _config;
         sparql::SparqlWrapper _sparql;
         sparql::QueryWriter _queryWriter;
-        OsmDataFetcher _odf;
+        OsmDataFetcher* _odf;
 
         /**
          * Osmium handler for the nodes in the change file.

--- a/include/osm/OsmDataFetcherQLever.h
+++ b/include/osm/OsmDataFetcherQLever.h
@@ -1,0 +1,95 @@
+//
+// Created by Nicolas von Trott on 27.05.25.
+//
+
+#ifndef OSMDATAFETCHERQLEVER_H
+#define OSMDATAFETCHERQLEVER_H
+#include <set>
+#include <string>
+
+#include "simdjson.h"
+
+#include "osm/OsmDataFetcher.h"
+#include "osm/Node.h"
+#include "osm/Relation.h"
+#include "osm/Way.h"
+#include "sparql/SparqlWrapper.h"
+#include "sparql/QueryWriter.h"
+#include "util/Types.h"
+
+namespace olu::osm {
+    class OsmDataFetcherQLever final : public OsmDataFetcher {
+    public:
+        explicit OsmDataFetcherQLever(const config::Config &config)
+            : _config(config), _sparqlWrapper(config), _queryWriter(config) { }
+
+        std::vector<Node> fetchNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<Relation> fetchRelations(const std::set<id_t> &relationIds) override;
+
+        void fetchRelationInfos(Relation &relation) override;
+
+        std::vector<Way> fetchWays(const std::set<id_t> &wayIds) override;
+
+        void fetchWayInfos(Way &way) override;
+
+        member_ids_t fetchWaysMembers(const std::set<id_t> &wayIds) override;
+
+        std::vector<std::pair<id_t, member_ids_t>>
+        fetchWaysMembersSorted(const std::set<id_t> &wayIds) override;
+
+        std::vector<std::pair<id_t, std::vector<RelationMember>>>
+        fetchRelsMembersSorted(const std::set<id_t> &relIds) override;
+
+        std::pair<std::vector<id_t>, std::vector<id_t>>
+        fetchRelationMembers(const std::set<id_t> &relIds) override;
+
+        std::string fetchLatestTimestampOfAnyNode() override;
+
+        std::vector<id_t> fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<id_t> fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<id_t> fetchRelationsReferencingWays(const std::set<id_t> &wayIds) override;
+
+        std::vector<id_t>
+        fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) override;
+    private:
+        config::Config _config;
+        sparql::SparqlWrapper _sparqlWrapper;
+        sparql::QueryWriter _queryWriter;
+        simdjson::ondemand::parser _parser;
+
+        simdjson::padded_string runQuery(const std::string &query,
+                                         const std::vector<std::string> &prefixes);
+
+        /**
+         * Parses the items in a list that is delimited by ";" and applies the given function to
+         * each item in the list.
+         * @tparam T The return type of the function that is applied to each item in the list
+         * @param list The list of items that are delimited by ";"
+         * @param function The function to apply to each item in the list
+         * @return A vector containing the manipulated items of the list.
+         */
+        template <typename T> std::vector<T>
+        parseValueList(const std::string_view &list, std::function<T(std::string)> function);
+
+        /**
+         * Iterates over the results of the given response and applies the given function to each
+         * JSON element in "res".
+         */
+        void forResults(const simdjson::padded_string &response,
+                        std::function<void(simdjson::ondemand::value)> func);
+
+        /**
+         * Returns the JSON element at "results.bindings" for the given document.
+         */
+        static simdjson::ondemand::value getResults(simdjson::ondemand::document &doc);
+
+        /**
+         * Returns the string at the "value" element for the given JSON element.
+         */
+        template <typename T> static T getValue(simdjson::ondemand::value value);
+    };
+}
+#endif //OSMDATAFETCHERQLEVER_H

--- a/include/osm/OsmDataFetcherQLever.h
+++ b/include/osm/OsmDataFetcherQLever.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "simdjson.h"
+#include "StatisticsHandler.h"
 
 #include "osm/OsmDataFetcher.h"
 #include "osm/Node.h"
@@ -20,8 +21,9 @@
 namespace olu::osm {
     class OsmDataFetcherQLever final : public OsmDataFetcher {
     public:
-        explicit OsmDataFetcherQLever(const config::Config &config)
-            : _config(config), _sparqlWrapper(config), _queryWriter(config) { }
+        explicit OsmDataFetcherQLever(const config::Config &config, StatisticsHandler &stats)
+            : _config(config), _stats(&stats),  _sparqlWrapper(config),
+              _queryWriter(config) { }
 
         std::vector<Node> fetchNodes(const std::set<id_t> &nodeIds) override;
 
@@ -56,6 +58,7 @@ namespace olu::osm {
         fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) override;
     private:
         config::Config _config;
+        StatisticsHandler* _stats;
         sparql::SparqlWrapper _sparqlWrapper;
         sparql::QueryWriter _queryWriter;
         simdjson::ondemand::parser _parser;

--- a/include/osm/OsmDataFetcherQLever.h
+++ b/include/osm/OsmDataFetcherQLever.h
@@ -63,8 +63,9 @@ namespace olu::osm {
         sparql::QueryWriter _queryWriter;
         simdjson::ondemand::parser _parser;
 
-        simdjson::padded_string runQuery(const std::string &query,
-                                         const std::vector<std::string> &prefixes);
+        void runQuery(const std::string &query,
+                      const std::vector<std::string> &prefixes,
+                      std::function<void(simdjson::ondemand::value)> resultFunc);
 
         /**
          * Parses the items in a list that is delimited by ";" and applies the given function to

--- a/include/osm/OsmDataFetcherSparql.h
+++ b/include/osm/OsmDataFetcherSparql.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "simdjson.h"
+#include "StatisticsHandler.h"
 
 #include "osm/OsmDataFetcher.h"
 #include "osm/Node.h"
@@ -21,8 +22,8 @@
 namespace olu::osm {
     class OsmDataFetcherSparql final : public OsmDataFetcher {
     public:
-        explicit OsmDataFetcherSparql(const config::Config &config)
-            : _config(config), _sparqlWrapper(config), _queryWriter(config) { }
+        explicit OsmDataFetcherSparql(const config::Config &config, StatisticsHandler &stats)
+            : _config(config), _stats(&stats), _sparqlWrapper(config), _queryWriter(config) { }
 
         std::vector<Node> fetchNodes(const std::set<id_t> &nodeIds) override;
 
@@ -57,6 +58,7 @@ namespace olu::osm {
         fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) override;
     private:
         config::Config _config;
+        StatisticsHandler* _stats;
         sparql::SparqlWrapper _sparqlWrapper;
         sparql::QueryWriter _queryWriter;
         simdjson::ondemand::parser _parser;

--- a/include/osm/OsmDataFetcherSparql.h
+++ b/include/osm/OsmDataFetcherSparql.h
@@ -1,0 +1,91 @@
+//
+// Created by Nicolas von Trott on 27.05.25.
+//
+
+#ifndef OSMDATAFETCHERSPARQL_H
+#define OSMDATAFETCHERSPARQL_H
+
+#include <set>
+#include <string>
+
+#include "simdjson.h"
+
+#include "osm/OsmDataFetcher.h"
+#include "osm/Node.h"
+#include "osm/Relation.h"
+#include "osm/Way.h"
+#include "sparql/SparqlWrapper.h"
+#include "sparql/QueryWriter.h"
+#include "util/Types.h"
+
+namespace olu::osm {
+    class OsmDataFetcherSparql final : public OsmDataFetcher {
+    public:
+        explicit OsmDataFetcherSparql(const config::Config &config)
+            : _config(config), _sparqlWrapper(config), _queryWriter(config) { }
+
+        std::vector<Node> fetchNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<Relation> fetchRelations(const std::set<id_t> &relationIds) override;
+
+        void fetchRelationInfos(Relation &relation) override;
+
+        std::vector<Way> fetchWays(const std::set<id_t> &wayIds) override;
+
+        void fetchWayInfos(Way &way) override;
+
+        member_ids_t fetchWaysMembers(const std::set<id_t> &wayIds) override;
+
+        std::vector<std::pair<id_t, member_ids_t>>
+        fetchWaysMembersSorted(const std::set<id_t> &wayIds) override;
+
+        std::vector<std::pair<id_t, std::vector<RelationMember>>>
+        fetchRelsMembersSorted(const std::set<id_t> &relIds) override;
+
+        std::pair<std::vector<id_t>, std::vector<id_t>>
+        fetchRelationMembers(const std::set<id_t> &relIds) override;
+
+        std::string fetchLatestTimestampOfAnyNode() override;
+
+        std::vector<id_t> fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<id_t> fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) override;
+
+        std::vector<id_t> fetchRelationsReferencingWays(const std::set<id_t> &wayIds) override;
+
+        std::vector<id_t>
+        fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) override;
+    private:
+        config::Config _config;
+        sparql::SparqlWrapper _sparqlWrapper;
+        sparql::QueryWriter _queryWriter;
+        simdjson::ondemand::parser _parser;
+
+        simdjson::padded_string runQuery(const std::string &query,
+                                         const std::vector<std::string> &prefixes);
+
+        /**
+         * Parses the items in a list that is delimited by ";" and applies the given function to
+         * each item in the list.
+         * @tparam T The return type of the function that is applied to each item in the list
+         * @param list The list of items that are delimited by ";"
+         * @param function The function to apply to each item in the list
+         * @return A vector containing the manipulated items of the list.
+         */
+        template <typename T> std::vector<T>
+        parseValueList(const std::string_view &list, std::function<T(std::string)> function);
+
+        /**
+         * Returns the JSON element at "results.bindings" for the given document.
+         */
+        static simdjson::simdjson_result<simdjson::ondemand::value> getBindings(
+            simdjson::simdjson_result<simdjson::ondemand::document> &doc);
+
+        /**
+         * Returns the string at the "value" element for the given JSON element.
+         */
+        template <typename T> static T getValue(
+            simdjson::simdjson_result<simdjson::ondemand::value> value);
+    };
+}
+#endif //OSMDATAFETCHERSPARQL_H

--- a/include/osm/OsmReplicationServerHelper.h
+++ b/include/osm/OsmReplicationServerHelper.h
@@ -20,6 +20,7 @@
 #define OSMREPLICATIONSERVERHELPER_H
 
 #include <string>
+#include <vector>
 
 #include "config/Config.h"
 #include "osm/OsmDatabaseState.h"
@@ -88,6 +89,18 @@ namespace olu::osm {
          * @return The database state described by the state file
          */
         static OsmDatabaseState extractStateFromStateFile(const std::string& stateFile);
+
+        /**
+         * Fetches the state files for the sequence numbers between `fromSeqNum` and `toSeqNum`
+         * from the server and returns a vector with the extracted database states.
+         *
+         * @param fromSeqNum Sequence number to start fetching from
+         * @param toSeqNum Sequence number to stop fetching at
+         * @return A vector containing the database states for the sequence numbers between
+         * `fromSeqNum` and `toSeqNum` sorted by sequence number in descending order.
+         */
+        std::vector<OsmDatabaseState>
+        fetchDatabaseStatesForSequenceNumbers(int fromSeqNum, int toSeqNum) const;
     };
 
     /**

--- a/include/osm/OsmUpdater.h
+++ b/include/osm/OsmUpdater.h
@@ -42,7 +42,7 @@ namespace olu::osm {
     private:
         config::Config _config;
         OsmReplicationServerHelper _repServer;
-        OsmDataFetcher _odf;
+        std::unique_ptr<OsmDataFetcher> _odf;
         OsmDatabaseState _latestState;
 
         /**

--- a/include/osm/OsmUpdater.h
+++ b/include/osm/OsmUpdater.h
@@ -20,6 +20,7 @@
 #define OSM_LIVE_UPDATES_OSMUPDATER_H
 
 #include "config/Config.h"
+#include "osm/StatisticsHandler.h"
 #include "osm/OsmDatabaseState.h"
 #include "osm/OsmDataFetcher.h"
 #include "osm/OsmReplicationServerHelper.h"
@@ -42,6 +43,7 @@ namespace olu::osm {
     private:
         config::Config _config;
         OsmReplicationServerHelper _repServer;
+        StatisticsHandler _stats;
         std::unique_ptr<OsmDataFetcher> _odf;
         OsmDatabaseState _latestState;
 
@@ -61,7 +63,7 @@ namespace olu::osm {
          *
          * @return The sequence number to start from
          */
-        [[nodiscard]] int decideStartSequenceNumber();
+        [[nodiscard]] int decideStartSequenceNumber() const;
 
         /**
         * Download all change files from the given sequence number to the `latest` one, and store

--- a/include/osm/ReferencesHandler.h
+++ b/include/osm/ReferencesHandler.h
@@ -34,7 +34,7 @@ namespace olu::osm {
                                    WayHandler &wayHandler,
                                    RelationHandler &relationHandler):
             _config(config),
-            _odf(odf),
+            _odf(&odf),
             _nodeHandler(nodeHandler),
             _wayHandler(wayHandler),
             _relationHandler(relationHandler) {}
@@ -72,7 +72,7 @@ namespace olu::osm {
 
     private:
         config::Config& _config;
-        OsmDataFetcher& _odf;
+        OsmDataFetcher* _odf;
         NodeHandler& _nodeHandler;
         WayHandler& _wayHandler;
         RelationHandler& _relationHandler;

--- a/include/osm/RelationHandler.h
+++ b/include/osm/RelationHandler.h
@@ -29,7 +29,8 @@
 namespace olu::osm {
     class RelationHandler: public osmium::handler::Handler {
     public:
-        explicit RelationHandler(const config::Config &config): _config(config), _odf(config) {}
+        explicit RelationHandler(const config::Config &config,
+                                 OsmDataFetcher &odf): _config(config), _odf(&odf) {}
 
         // Iterator for osmium::apply
         void relation(const osmium::Relation& relation);
@@ -112,7 +113,7 @@ namespace olu::osm {
 
     private:
         config::Config _config;
-        OsmDataFetcher _odf;
+        OsmDataFetcher* _odf;
 
         // Relations that are in a delete-changeset in the change file.
         std::set<id_t> _deletedRelations;

--- a/include/osm/RelationHandler.h
+++ b/include/osm/RelationHandler.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <set>
 
+#include "StatisticsHandler.h"
 #include "osmium/handler.hpp"
 
 #include "osm/OsmDataFetcher.h"
@@ -29,8 +30,9 @@
 namespace olu::osm {
     class RelationHandler: public osmium::handler::Handler {
     public:
-        explicit RelationHandler(const config::Config &config,
-                                 OsmDataFetcher &odf): _config(config), _odf(&odf) {}
+        explicit RelationHandler(const config::Config &config, OsmDataFetcher &odf,
+                                 StatisticsHandler &stats): _config(config), _odf(&odf),
+                                                            _stats(&stats) {}
 
         // Iterator for osmium::apply
         void relation(const osmium::Relation& relation);
@@ -57,8 +59,6 @@ namespace olu::osm {
                    _modifiedRelationsWithChangedMembers.size() +
                    _deletedRelations.size();
         }
-
-        void printRelationStatistics() const;
 
         /**
          * Checks if the members of the given relations from the change file have changed.
@@ -114,6 +114,7 @@ namespace olu::osm {
     private:
         config::Config _config;
         OsmDataFetcher* _odf;
+        StatisticsHandler* _stats;
 
         // Relations that are in a delete-changeset in the change file.
         std::set<id_t> _deletedRelations;

--- a/include/osm/StatisticsHandler.h
+++ b/include/osm/StatisticsHandler.h
@@ -1,0 +1,261 @@
+// Copyright 2025, University of Freiburg
+// Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
+
+// This file is part of osm-live-updates.
+//
+// osm-live-updates is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm-live-updates is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef STATISTICSHANDLER_H
+#define STATISTICSHANDLER_H
+
+#include <cstddef>
+#include <config/Config.h>
+#include <util/Types.h>
+
+namespace olu::osm {
+    class StatisticsHandler {
+    public:
+        explicit StatisticsHandler(const config::Config &config): _config(config) {};
+
+        void printCurrentStep(const std::string &stepDescription) const;
+
+        void printOsmStatistics() const;
+        void printUpdateStatistics() const;
+        void printOsm2RdfStatistics() const;
+        void printSparqlStatistics() const;
+        void printTimingStatistics() const;
+
+        void startTime() { _startTime = std::chrono::system_clock::now(); }
+        void endTime() { _endTime = std::chrono::system_clock::now(); }
+        long getTimeInMSTotal() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTime - _startTime).count();
+        }
+
+        void startTimeDeterminingSequenceNumber() { _startTimeDeterminingSequenceNumber = std::chrono::system_clock::now(); }
+        void endTimeDeterminingSequenceNumber() { _endTimeDeterminingSequenceNumber = std::chrono::system_clock::now(); }
+        long getTimeInMSDeterminingSequenceNumber() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeDeterminingSequenceNumber - _startTimeDeterminingSequenceNumber).count();
+        }
+
+        void startTimeMergingChangeFiles() { _startTimeMergingChangeFiles = std::chrono::system_clock::now(); }
+        void endTimeMergingChangeFiles() { _endTimeMergingChangeFiles = std::chrono::system_clock::now(); }
+        long getTimeInMSMergingChangeFiles() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeMergingChangeFiles - _startTimeMergingChangeFiles).count();
+        }
+
+        void startTimeFetchingChangeFiles() { _startTimeFetchingChangeFiles = std::chrono::system_clock::now(); }
+        void endTimeFetchingChangeFiles() { _endTimeFetchingChangeFiles = std::chrono::system_clock::now(); }
+        long getTimeInMSFetchingChangeFiles() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeFetchingChangeFiles - _startTimeFetchingChangeFiles).count();
+        }
+
+        void startTimeProcessingChangeFiles() { _startTimeProcessingChangeFiles = std::chrono::system_clock::now(); }
+        void endTimeProcessingChangeFiles() { _endTimeProcessingChangeFiles = std::chrono::system_clock::now(); }
+        long getTimeInMSProcessingChangeFiles() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeProcessingChangeFiles - _startTimeProcessingChangeFiles).count();
+        }
+
+        void startTimeCheckingNodeLocations() { _startTimeCheckingNodeLocations = std::chrono::system_clock::now(); }
+        void endTimeCheckingNodeLocations() { _endTimeCheckingNodeLocations = std::chrono::system_clock::now(); }
+        long getTimeInMSCheckingNodeLocations() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeCheckingNodeLocations - _startTimeCheckingNodeLocations).count();
+        }
+
+        void startTimeCheckingWayMembers() { _startTimeCheckingWayMembers = std::chrono::system_clock::now(); }
+        void endTimeCheckingWayMembers() { _endTimeCheckingWayMembers = std::chrono::system_clock::now(); }
+        long getTimeInMSCheckingWayMembers() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeCheckingWayMembers - _startTimeCheckingWayMembers).count();
+        }
+
+        void startTimeCheckingRelationMembers() { _startTimeCheckingRelationMembers = std::chrono::system_clock::now(); }
+        void endTimeCheckingRelationMembers() { _endTimeCheckingRelationMembers = std::chrono::system_clock::now(); }
+        long getTimeInMSCheckingRelationMembers() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeCheckingRelationMembers - _startTimeCheckingRelationMembers).count();
+        }
+
+        void startTimeFetchingObjectsToUpdateGeo() { _startTimeFetchingObjectsToUpdateGeo = std::chrono::system_clock::now(); }
+        void endTimeFetchingObjectsToUpdateGeo() { _endTimeFetchingObjectsToUpdateGeo = std::chrono::system_clock::now(); }
+        long getTimeInMSFetchingObjectsToUpdateGeo() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeFetchingObjectsToUpdateGeo - _startTimeFetchingObjectsToUpdateGeo).count();
+        }
+
+        void startTimeFetchingReferences() { _startTimeFetchingReferences = std::chrono::system_clock::now(); }
+        void endTimeFetchingReferences() { _endTimeFetchingReferences = std::chrono::system_clock::now(); }
+        long getTimeInMSFetchingReferences() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeFetchingReferences - _startTimeFetchingReferences).count();
+        }
+
+        void startTimeCreatingDummys() { _startTimeCreatingDummys = std::chrono::system_clock::now(); }
+        void endTimeCreatingDummys() { _endTimeCreatingDummys = std::chrono::system_clock::now(); }
+        long getTimeInMSCreatingDummys() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeCreatingDummys - _startTimeCreatingDummys).count();
+        }
+
+        void startTimeOsm2RdfConversion() { _startTimeOsm2RdfConversion = std::chrono::system_clock::now(); }
+        void endTimeOsm2RdfConversion() { _endTimeOsm2RdfConversion = std::chrono::system_clock::now(); }
+        long getTimeInMSOsm2RdfConversion() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeOsm2RdfConversion - _startTimeOsm2RdfConversion).count();
+        }
+
+        void startTimeDeletingTriples() { _startTimeDeletingTriples = std::chrono::system_clock::now(); }
+        void endTimeDeletingTriples() { _endTimeDeletingTriples = std::chrono::system_clock::now(); }
+        long getTimeInMSDeletingTriples() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeDeletingTriples - _startTimeDeletingTriples).count();
+        }
+
+        void startTimeFilteringTriples() { _startTimeFilteringTriples = std::chrono::system_clock::now(); }
+        void endTimeFilteringTriples() { _endTimeFilteringTriples = std::chrono::system_clock::now(); }
+        long getTimeInMSFilteringTriples() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeFilteringTriples - _startTimeFilteringTriples).count();
+        }
+
+        void startTimeInsertingTriples() { _startTimeInsertingTriples = std::chrono::system_clock::now(); }
+        void endTimeInsertingTriples() { _endTimeInsertingTriples = std::chrono::system_clock::now(); }
+        long getTimeInMSInsertingTriples() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeInsertingTriples - _startTimeInsertingTriples).count();
+        }
+
+        void setNumberOfNodesWithLocationChange(const size_t num) { _numOfNodesWithLocationChange = num; }
+        void setNumberOfWaysWithMemberChange(const size_t num) { _numOfWaysWithMemberChange = num; }
+        void setNumberOfRelationsWithMemberChange(const size_t num) { _numOfRelationsWithMemberChange = num; }
+        void setNumberOfWaysToUpdateGeometry(const size_t num) { _numOfWaysToUpdateGeometry = num; }
+        void setNumberOfRelationsToUpdateGeometry(const size_t num) { _numOfRelationsToUpdateGeometry = num; }
+        void setNumberOfTriplesToInsert(const size_t num) { _numOfTriplesToInsert = num; }
+
+        void countCreatedNode() { ++_numOfCreatedNodes; }
+        void countModifiedNode() { ++_numOfModifiedNodes; }
+        void countDeletedNode() { ++_numOfDeletedNodes; }
+        void switchModifiedToCreatedNode() { ++_numOfCreatedNodes; --_numOfModifiedNodes; }
+        void countNodeWithLocationChange() { ++_numOfNodesWithLocationChange; }
+
+        void countCreatedWay() { ++_numOfCreatedWays; }
+        void countModifiedWay() { ++_numOfModifiedWays; }
+        void countDeletedWay() { ++_numOfDeletedWays; }
+        void switchModifiedToCreatedWay() { ++_numOfCreatedWays; --_numOfModifiedWays; }
+        void countWayWithMemberChange() { ++_numOfWaysWithMemberChange; }
+
+        void countCreatedRelation() { ++_numOfCreatedRelations; }
+        void countModifiedRelation() { ++_numOfModifiedRelations; }
+        void countDeletedRelation() { ++_numOfDeletedRelations; }
+        void switchModifiedToCreatedRelation() { ++_numOfCreatedRelations; --_numOfModifiedRelations; }
+        void countRelationWithMemberChange() { ++_numOfRelationsWithMemberChange; }
+
+        void countWayToUpdateGeometry() { ++_numOfWaysToUpdateGeometry; }
+        void countRelationToUpdateGeometry() { ++_numOfRelationsToUpdateGeometry; }
+
+        void countDummyNode() { ++_numOfDummyNodes; }
+        void countDummyWay() { ++_numOfDummyWays; }
+        void countDummyRelation() { ++_numOfDummyRelations; }
+
+        void countQuery() { ++_queriesCount; }
+        void countUpdateQuery() { ++_updateQueriesCount; }
+        void countTriple() { ++_numOfConvertedTriples; }
+        void countQleverResponseTime(const size_t timeInMs) { _qleverResponseTimeMs += timeInMs; }
+        void countQleverUpdateTime(const size_t timeInMs) {  _qleverUpdateTimeMs += timeInMs; }
+    private:
+        config::Config _config;
+
+        size_t _numOfCreatedNodes = 0;
+        size_t _numOfModifiedNodes = 0;
+        size_t _numOfDeletedNodes = 0;
+        size_t numOfNodes() const {return _numOfCreatedNodes + _numOfModifiedNodes + _numOfDeletedNodes;}
+        size_t _numOfNodesWithLocationChange = 0;
+
+        size_t _numOfCreatedWays = 0;
+        size_t _numOfModifiedWays = 0;
+        size_t _numOfDeletedWays = 0;
+        size_t numOfWays() const { return _numOfCreatedWays + _numOfModifiedWays + _numOfDeletedWays; }
+        size_t _numOfWaysWithMemberChange = 0;
+        size_t _numOfWaysToUpdateGeometry = 0;
+
+        size_t _numOfCreatedRelations = 0;
+        size_t _numOfModifiedRelations = 0;
+        size_t _numOfDeletedRelations = 0;
+        size_t numOfRelations() const { return _numOfCreatedRelations + _numOfModifiedRelations + _numOfDeletedRelations; }
+        size_t _numOfRelationsWithMemberChange = 0;
+        size_t _numOfRelationsToUpdateGeometry = 0;
+
+        size_t _numOfDummyNodes = 0;
+        size_t _numOfDummyWays  = 0;
+        size_t _numOfDummyRelations = 0;
+
+        size_t _numOfConvertedTriples = 0;
+        size_t _numOfTriplesToInsert = 0;
+
+        size_t _queriesCount = 0;
+        size_t _updateQueriesCount = 0;
+
+        size_t _qleverResponseTimeMs = 0;
+        size_t _qleverUpdateTimeMs = 0;
+
+        time_point_t _startTime;
+        time_point_t _endTime;
+
+        time_point_t _startTimeDeterminingSequenceNumber;
+        time_point_t _endTimeDeterminingSequenceNumber;
+
+        time_point_t _startTimeMergingChangeFiles;
+        time_point_t _endTimeMergingChangeFiles;
+
+        time_point_t _startTimeFetchingChangeFiles;
+        time_point_t _endTimeFetchingChangeFiles;
+
+        time_point_t _startTimeProcessingChangeFiles;
+        time_point_t _endTimeProcessingChangeFiles;
+
+        time_point_t _startTimeCheckingNodeLocations;
+        time_point_t _endTimeCheckingNodeLocations;
+
+        time_point_t _startTimeCheckingWayMembers;
+        time_point_t _endTimeCheckingWayMembers;
+
+        time_point_t _startTimeCheckingRelationMembers;
+        time_point_t _endTimeCheckingRelationMembers;
+
+        time_point_t _startTimeFetchingObjectsToUpdateGeo;
+        time_point_t _endTimeFetchingObjectsToUpdateGeo;
+
+        time_point_t _startTimeFetchingReferences;
+        time_point_t _endTimeFetchingReferences;
+
+        time_point_t _startTimeCreatingDummys;
+        time_point_t _endTimeCreatingDummys;
+
+        time_point_t _startTimeOsm2RdfConversion;
+        time_point_t _endTimeOsm2RdfConversion;
+
+        time_point_t _startTimeDeletingTriples;
+        time_point_t _endTimeDeletingTriples;
+
+        time_point_t _startTimeFilteringTriples;
+        time_point_t _endTimeFilteringTriples;
+
+        time_point_t _startTimeInsertingTriples;
+        time_point_t _endTimeInsertingTriples;
+
+        static double calculatePercentage(const size_t total, const size_t part) {
+            if (total == 0) {
+                return 0.0;
+            }
+            return static_cast<double>(part) / static_cast<double>(total) * 100.0;
+        }
+
+        double calculatePercentageOfTotalTime(const size_t part) const {
+            return static_cast<double>(part) /
+                   static_cast<double>(getTimeInMSTotal()) * 100.0;
+        }
+    };
+}
+
+#endif //STATISTICSHANDLER_H

--- a/include/osm/StatisticsHandler.h
+++ b/include/osm/StatisticsHandler.h
@@ -166,10 +166,11 @@ namespace olu::osm {
         void countUpdateQuery() { ++_updateQueriesCount; }
         void countTriple() { ++_numOfConvertedTriples; }
 
-        void logQleverTimingInfoQuery(simdjson::ondemand::object timeResult);
-        void logQleverTimingInfoUpdate(simdjson::ondemand::object timeResult);
+        void logQleverQueryInfo(simdjson::ondemand::object qleverResponse);
+        void logQLeverUpdateInfo(const simdjson::padded_string &qleverResponse);
     private:
         config::Config _config;
+        simdjson::ondemand::parser _parser;
 
         size_t _numOfCreatedNodes = 0;
         size_t _numOfModifiedNodes = 0;
@@ -203,6 +204,8 @@ namespace olu::osm {
 
         size_t _qleverResponseTimeMs = 0;
         size_t _qleverUpdateTimeMs = 0;
+        size_t _qleverInsertedTriplesCount = 0;
+        size_t _qleverDeletedTriplesCount = 0;
 
         time_point_t _startTime;
         time_point_t _endTime;
@@ -263,6 +266,20 @@ namespace olu::osm {
 
         void countQleverResponseTime(const std::string_view &timeInMs);
         void countQleverUpdateTime(const std::string_view &timeInMs);
+    };
+
+    /**
+     * Exception that can appear inside the `StatisticsHandler` class.
+     */
+    class StatisticsHandlerException final : public std::exception {
+        std::string message;
+
+    public:
+        explicit StatisticsHandlerException(const char *msg) : message(msg) { }
+
+        [[nodiscard]] const char *what() const noexcept override {
+            return message.c_str();
+        }
     };
 }
 

--- a/include/osm/StatisticsHandler.h
+++ b/include/osm/StatisticsHandler.h
@@ -19,7 +19,11 @@
 #ifndef STATISTICSHANDLER_H
 #define STATISTICSHANDLER_H
 
+#include <string>
 #include <cstddef>
+
+#include "simdjson.h"
+
 #include <config/Config.h>
 #include <util/Types.h>
 
@@ -161,8 +165,9 @@ namespace olu::osm {
         void countQuery() { ++_queriesCount; }
         void countUpdateQuery() { ++_updateQueriesCount; }
         void countTriple() { ++_numOfConvertedTriples; }
-        void countQleverResponseTime(const size_t timeInMs) { _qleverResponseTimeMs += timeInMs; }
-        void countQleverUpdateTime(const size_t timeInMs) {  _qleverUpdateTimeMs += timeInMs; }
+
+        void logQleverTimingInfoQuery(simdjson::ondemand::object timeResult);
+        void logQleverTimingInfoUpdate(simdjson::ondemand::object timeResult);
     private:
         config::Config _config;
 
@@ -255,6 +260,9 @@ namespace olu::osm {
             return static_cast<double>(part) /
                    static_cast<double>(getTimeInMSTotal()) * 100.0;
         }
+
+        void countQleverResponseTime(const std::string_view &timeInMs);
+        void countQleverUpdateTime(const std::string_view &timeInMs);
     };
 }
 

--- a/include/osm/WayHandler.h
+++ b/include/osm/WayHandler.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <set>
 
+#include "StatisticsHandler.h"
 #include "osmium/handler.hpp"
 
 #include "osm/OsmDataFetcher.h"
@@ -30,7 +31,9 @@ namespace olu::osm {
 
     class WayHandler: public osmium::handler::Handler {
     public:
-        explicit WayHandler(const config::Config &config, OsmDataFetcher &odf): _config(config), _odf(&odf) {}
+        explicit WayHandler(const config::Config &config, OsmDataFetcher &odf,
+                            StatisticsHandler &stats): _config(config), _odf(&odf),
+                                                       _stats(&stats) { }
 
         // Iterator for osmium::apply
         void way(const osmium::Way& way);
@@ -48,8 +51,6 @@ namespace olu::osm {
                    _modifiedWaysWithChangedMembers.size() +
                    _deletedWays.size();
         }
-
-        void printWayStatistics() const;
 
         /**
          * Checks if the members of the given ways from the change file have changed. If so, the
@@ -88,6 +89,7 @@ namespace olu::osm {
     private:
         config::Config _config;
         OsmDataFetcher* _odf;
+        StatisticsHandler* _stats;
 
         // Ways that are in a delete-changeset in the change file.
         std::set<id_t> _deletedWays;

--- a/include/osm/WayHandler.h
+++ b/include/osm/WayHandler.h
@@ -30,7 +30,7 @@ namespace olu::osm {
 
     class WayHandler: public osmium::handler::Handler {
     public:
-        explicit WayHandler(const config::Config &config): _config(config), _odf(config) {}
+        explicit WayHandler(const config::Config &config, OsmDataFetcher &odf): _config(config), _odf(&odf) {}
 
         // Iterator for osmium::apply
         void way(const osmium::Way& way);
@@ -87,7 +87,7 @@ namespace olu::osm {
 
     private:
         config::Config _config;
-        OsmDataFetcher _odf;
+        OsmDataFetcher* _odf;
 
         // Ways that are in a delete-changeset in the change file.
         std::set<id_t> _deletedWays;

--- a/include/sparql/SparqlWrapper.h
+++ b/include/sparql/SparqlWrapper.h
@@ -82,7 +82,7 @@ namespace olu::sparql {
         /**
          * Sends a HTTP request to the sparql endpoint.
          */
-        std::string send(const std::string& acceptValue, bool isUpdate);
+        std::string send(bool isUpdate);
     };
 
     /**

--- a/include/sparql/SparqlWrapper.h
+++ b/include/sparql/SparqlWrapper.h
@@ -71,7 +71,7 @@ namespace olu::sparql {
          *
          * @return The response from the SPARQL endpoint.
          */
-        void runUpdate();
+        std::string runUpdate();
     private:
         config::Config _config;
         std::string _query;

--- a/include/util/Time.h
+++ b/include/util/Time.h
@@ -1,0 +1,49 @@
+// Copyright 2025, University of Freiburg
+// Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
+
+// This file is part of osm-live-updates.
+//
+// osm-live-updates is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm-live-updates is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef OLU_UTIL_TIME_H
+#define OLU_UTIL_TIME_H
+
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace olu::util {
+
+inline const char* formattedTimeSpacer = "                          ";
+
+    // Return current time formatted as string.
+    // https://github.com/ad-freiburg/osm2rdf/blob/master/include/osm2rdf/util/Time.h
+    inline std::string currentTimeFormatted() {
+      std::ostringstream oss;
+      char tl[20];
+      auto n = std::chrono::system_clock::now();
+      time_t tt = std::chrono::system_clock::to_time_t(n);
+      int m = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  n - std::chrono::time_point_cast<std::chrono::seconds>(n))
+                  .count();
+      struct tm t = *localtime(&tt);
+      strftime(tl, 20, "%Y-%m-%d %H:%M:%S", &t);
+      oss << "[" << tl << "." << std::setfill('0') << std::setw(3) << m << "] ";
+      return oss.str();
+    }
+
+}
+
+#endif  // OLU_UTIL_TIME_H

--- a/include/util/Types.h
+++ b/include/util/Types.h
@@ -19,6 +19,7 @@
 #ifndef OSM_LIVE_UPDATES_TYPES_H
 #define OSM_LIVE_UPDATES_TYPES_H
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -35,6 +36,8 @@ namespace olu {
 
     typedef std::tuple<std::string, std::string, std::string> triple_t;
     typedef std::pair<std::string, std::string> key_value_t;
+
+    typedef std::chrono::time_point<std::chrono::system_clock> time_point_t;
 }
 
 #endif //OSM_LIVE_UPDATES_TYPES_H

--- a/include/util/XmlHelper.h
+++ b/include/util/XmlHelper.h
@@ -19,9 +19,23 @@
 #ifndef OSM_LIVE_UPDATES_XMLHELPER_H
 #define OSM_LIVE_UPDATES_XMLHELPER_H
 
+#include <iostream>
 #include <string>
 
 namespace olu::util {
+    /**
+     * Exception that can appear inside the `XmlHelper` class.
+     */
+    class XmlHelperException final : public std::exception {
+        std::string message;
+
+    public:
+        explicit XmlHelperException(const char* msg) : message(msg) { }
+
+        [[nodiscard]] const char* what() const noexcept override {
+            return message.c_str();
+        }
+    };
 
     /**
      * Helper class for dealing with XML Files.
@@ -42,6 +56,69 @@ namespace olu::util {
          * Decodes string for XML format.
          */
         static std::string xmlDecode(const std::string &input);
+
+        /**
+         * Parses a given string in the form of "<http://www.openstreetmap.org/wiki/Key:keyname>"
+         * and returns the key name part.
+         *
+         * @param uri The input string to parse.
+         * @return The key name part of the URI.
+         */
+        static std::string parseKeyName(const std::string& uri);
+
+        /**
+         * Parses a given string in rdf syntax (Example:
+         * "\"2023-12-30T17:07:40\"^^<http://www.w3.org/2001/XMLSchema#dateTime>") or a string
+         * in quotation marks (Example: "\"2023-12-30T17:07:40\"") and return the content inside
+         * the quotation marks.
+         *
+         * @param input The input string to parse.
+         * @return
+         */
+         template <typename T> static T parseRdfString(const std::string &input) {
+             const auto end = input.find("^^");
+             std::string output;
+             if (end == std::string::npos) {
+                 // Input has no rdf syntax, just return the content inside the quotation marks
+                 if (input.front() != '"' || input.back() != '"') {
+                     const std::string msg = "Cannot parse string: " + input;
+                     throw XmlHelperException(msg.c_str());
+                 }
+                 output = input.substr(1, input.size() - 2);
+             } else {
+                 output = input.substr(1, end - 2);
+             }
+
+             if constexpr (std::is_same_v<T, std::string>) {
+                 return output;
+             } else if constexpr (std::is_same_v<T, int>) {
+                 try {
+                     return std::stoi(output);
+                 } catch (const std::exception &e) {
+                     std::cerr << e.what() << std::endl;
+                     const std::string msg = "Cannot parse integer from rdf string: " + output;
+                     throw XmlHelperException(msg.c_str());
+                 }
+             } else if constexpr (std::is_same_v<T, float>) {
+                 try {
+                     return std::stof(output);
+                 } catch (const std::exception &e) {
+                     std::cerr << e.what() << std::endl;
+                     const std::string msg = "Cannot parse float from rdf string: " + output;
+                     throw XmlHelperException(msg.c_str());
+                 }
+             } else if constexpr (std::is_same_v<T, double>) {
+                 try {
+                     return std::stod(output);
+                 } catch (const std::exception &e) {
+                     std::cerr << e.what() << std::endl;
+                     const std::string msg = "Cannot parse double from rdf string: " + output;
+                     throw XmlHelperException(msg.c_str());
+                 }
+             }
+
+             throw XmlHelperException("Unsupported return type for rdf string.");
+         }
     };
 
 } // namespace  olu::util

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -116,6 +116,11 @@ void olu::config::Config::fromArgs(const int argc, char **argv) {
         constants::QLEVER_ENDPOINT_OPTION_LONG,
         constants::QLEVER_ENDPOINT_OPTION_HELP);
 
+    const auto showStatisticsOp = parser.add<popl::Switch,
+        popl::Attribute::advanced>(
+        constants::STATISTICS_OPTION_SHORT,
+        constants::STATISTICS_OPTION_LONG,
+        constants::STATISTICS_OPTION_HELP);
 
     try {
         parser.parse(argc, argv);
@@ -227,6 +232,10 @@ void olu::config::Config::fromArgs(const int argc, char **argv) {
 
         if (isQleverEndpointOp->is_set()) {
             isQLever = true;
+        }
+
+        if (showStatisticsOp->is_set()) {
+            showDetailedStatistics = true;
         }
 
         if (sparqlOutputOp->is_set()) {

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -110,6 +110,13 @@ void olu::config::Config::fromArgs(const int argc, char **argv) {
         constants::BATCH_SIZE_OPTION_LONG,
         constants::BATCH_SIZE_OPTION_HELP);
 
+    const auto isQleverEndpointOp = parser.add<popl::Switch,
+        popl::Attribute::advanced>(
+        constants::QLEVER_ENDPOINT_OPTION_SHORT,
+        constants::QLEVER_ENDPOINT_OPTION_LONG,
+        constants::QLEVER_ENDPOINT_OPTION_HELP);
+
+
     try {
         parser.parse(argc, argv);
 
@@ -218,6 +225,10 @@ void olu::config::Config::fromArgs(const int argc, char **argv) {
             batchSize = batchSizeOp->value();
         }
 
+        if (isQleverEndpointOp->is_set()) {
+            isQLever = true;
+        }
+
         if (sparqlOutputOp->is_set()) {
             sparqlOutputFile = sparqlOutputOp->value();
             sparqlOutput = sparqlOutputFormatOp->is_set() ? DEBUG_FILE : FILE;
@@ -269,6 +280,14 @@ std::string olu::config::Config::getInfo(const std::string_view prefix) const {
     << " "
     << sparqlEndpointUri
     << std::endl;
+
+    if (isQLever) {
+        oss
+        << osm2rdf::util::currentTimeFormatted()
+        << prefix
+        << constants::QLEVER_ENDPOINT_INFO
+        << std::endl;
+    }
 
     if (!graphUri.empty()) {
         oss

--- a/src/osm/NodeHandler.cpp
+++ b/src/osm/NodeHandler.cpp
@@ -62,7 +62,7 @@ void olu::osm::NodeHandler::checkNodesForLocationChange() {
         nodeIds,
         _config.batchSize,
         [this, &remoteNodes](std::set<id_t> const& batch) mutable {
-            for (const auto& node : _odf.fetchNodes(batch)) {
+            for (const auto& node : _odf->fetchNodes(batch)) {
                 remoteNodes.emplace(node.getId(), node.getLocation());
             }
     });

--- a/src/osm/NodeHandler.cpp
+++ b/src/osm/NodeHandler.cpp
@@ -33,23 +33,17 @@ void olu::osm::NodeHandler::node(const osmium::Node& node) {
     switch (OsmObjectHelper::getChangeAction(node)) {
         case ChangeAction::CREATE:
             _createdNodes.insert(node.id());
+            _stats->countCreatedNode();
             break;
         case ChangeAction::MODIFY:
             _modifiedNodesBuffer.emplace(node.id(), node.location());
+            _stats->countModifiedNode();
             break;
         case ChangeAction::DELETE:
             _deletedNodes.insert(node.id());
+            _stats->countDeletedNode();
             break;
     }
-}
-
-// _________________________________________________________________________________________________
-void olu::osm::NodeHandler::printNodeStatistics() const {
-    std::cout << osm2rdf::util::currentTimeFormatted()
-    << "nodes created: " << _createdNodes.size()
-    << " modified: " << _modifiedNodes.size() + _modifiedNodesWithChangedLocation.size()
-    << " deleted: " << _deletedNodes.size()
-    << std::endl;
 }
 
 // _________________________________________________________________________________________________
@@ -73,12 +67,14 @@ void olu::osm::NodeHandler::checkNodesForLocationChange() {
                 _modifiedNodes.insert(localId);
             } else {
                 _modifiedNodesWithChangedLocation.insert(localId);
+                _stats->countNodeWithLocationChange();
             }
         } else {
             // If we cannot find the node location on the endpoint, we assume that the node has
             // to be created. (See OsmObjectHelper::getChangeAction for an explanation why this
             // could happen even if the node is in a modify-changeset)
             _createdNodes.insert(localId);
+            _stats->switchModifiedToCreatedNode();
         }
     }
 

--- a/src/osm/OsmChangeHandler.cpp
+++ b/src/osm/OsmChangeHandler.cpp
@@ -431,17 +431,7 @@ void olu::osm::OsmChangeHandler::runUpdateQuery(const std::string &query,
     if (_config.isQLever) {
         // Update responses are in "[]" so remove them before parsing
         response = response.substr(1, response.size() - 2);
-        for (auto doc = _parser.iterate(response);
-             auto field: doc.get_object()) {
-            if (field.error()) {
-                std::cerr << field.error() << std::endl;
-                throw OsmDataFetcherException("Error while parsing QLever update response.");
-            }
-
-            if (const std::string_view key = field.escaped_key(); key == cnst::KEY_QLEVER_TIME) {
-                _stats->logQleverTimingInfoUpdate(field.value().get_object());
-            }
-        }
+        _stats->logQLeverUpdateInfo(response);
     }
 }
 

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -62,7 +62,7 @@ void olu::osm::OsmDataFetcherQLever::runQuery(const std::string &query,
             }
         }
         if (key == cnst::KEY_QLEVER_TIME) {
-            _stats->logQleverTimingInfoQuery(field.value().get_object());
+            _stats->logQleverQueryInfo(field.value().get_object());
         }
     }
 }

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -260,7 +260,7 @@ namespace olu::osm {
                     }
                     case 4: {
                         const auto changesetId = getValue<std::string>(result.value());
-                        way.setChangesetId(util::XmlHelper::parseRdfString<int>(changesetId));
+                        way.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
                         break;
                     }
                     default:
@@ -314,7 +314,7 @@ namespace olu::osm {
                     }
                     case 4: {
                         const auto changesetId = getValue<std::string>(result.value());
-                        relation.setChangesetId(util::XmlHelper::parseRdfString<int>(changesetId));
+                        relation.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
                         break;
                     }
                     default:

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -1,0 +1,622 @@
+// Copyright 2024, University of Freiburg
+// Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
+
+// This file is part of osm-live-updates.
+//
+// osm-live-updates is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm-live-updates is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "osm/OsmDataFetcherQLever.h"
+
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <strstream>
+#include <spanstream>
+#include <util/XmlHelper.h>
+
+#include "simdjson.h"
+#include "boost/regex.hpp"
+
+#include "config/Constants.h"
+#include "osm/OsmObjectHelper.h"
+#include "osm/RelationMember.h"
+#include "sparql/QueryWriter.h"
+#include "util/Types.h"
+
+namespace cnst = olu::config::constants;
+
+// _________________________________________________________________________________________________
+simdjson::padded_string
+olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::runQuery(const std::string &query,
+                                                   const std::vector<std::string> &prefixes) {
+    _sparqlWrapper.setQuery(query);
+    _sparqlWrapper.setPrefixes(prefixes);
+    return {_sparqlWrapper.runQuery()};
+}
+
+// _________________________________________________________________________________________________
+std::vector<olu::osm::Node>
+olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchNodes(const std::set<id_t> &nodeIds) {
+    const auto response = runQuery(
+        _queryWriter.writeQueryForNodeLocations(nodeIds),
+        cnst::PREFIXES_FOR_NODE_LOCATION);
+
+    std::vector<Node> nodes;
+    nodes.reserve(nodeIds.size());
+
+    forResults(response, [&nodes](simdjson::ondemand::value results) {
+        auto it = results.begin();
+        const auto nodeUri = getValue<std::string_view>((*it).value());
+        ++it;
+        const auto nodeLocationAsWkt = getValue<std::string_view>((*it).value());
+        nodes.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri), wktPoint_t(nodeLocationAsWkt));
+    });
+
+    if (nodes.size() > nodeIds.size()) {
+        std::cerr << "The SPARQL endpoint returned " << std::to_string(nodes.size())
+                  << " locations, for " << std::to_string(nodeIds.size())
+                  << " nodes." << std::endl;
+        throw OsmDataFetcherException("Exception while trying to fetch nodes locations");
+    }
+
+    return nodes;
+}
+
+// _________________________________________________________________________________________________
+std::string olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchLatestTimestampOfAnyNode() {
+    const auto response = runQuery(
+        _queryWriter.writeQueryForLatestNodeTimestamp(),
+        cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP);
+
+    std::string timestamp;
+    const std::string timestampPath = "$.res[0][0]";
+    if (const auto error = _parser.iterate(response).at_path(timestampPath).get_string(timestamp);
+        error || timestamp.empty()) {
+        std::cerr << "JSON error: " << error << std::endl;
+        throw OsmDataFetcherException("Could not parse latest timestamp of any node from "
+                                      "sparql endpoint");
+    }
+
+    if (_config.isQLever) {
+        // QLever will return the timestamp in a format like:
+        // "\"2025-05-24T19:15:22\"^^<http://www.w3.org/2001/XMLSchema#dateTime>"
+        const boost::regex expr("\\\"([^\\\"]+)\\\"");
+        if (boost::smatch match; regex_search(timestamp, match, expr)) {
+            timestamp = match[1];
+        } else {
+            const std::string msg = "Could not extract timestamp from QLever"
+                                    " response: " + timestamp;
+            throw OsmDataFetcherException(msg.c_str());
+        }
+    }
+
+    return timestamp;
+}
+
+namespace olu::osm {
+    // _____________________________________________________________________________________________
+    std::vector<Relation>
+    OsmDataFetcherQLever::fetchRelations(const std::set<id_t> &relationIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForRelations(relationIds),
+            cnst::PREFIXES_FOR_RELATION_MEMBERS);
+
+        std::vector<Relation> relations;
+        relations.reserve(relationIds.size());
+
+        forResults(response, [&relations, this](simdjson::ondemand::value results) {
+            auto it = results.begin();
+            auto relationUri = getValue<std::string_view>((*it).value());
+            auto relationId = OsmObjectHelper::parseIdFromUri(relationUri);
+            Relation relation(relationId);
+
+            ++it;
+            auto relationType = getValue<std::string>((*it).value());
+            relation.setType(util::XmlHelper::parseRdfString<std::string>(relationType));
+
+            // Extract members for the relation
+            ++it;
+            auto memberUriList = getValue<std::string_view>((*it).value());
+            memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+            std::ispanstream uriStream(memberUriList);
+            ++it;
+            auto memberRolesList = getValue<std::string_view>((*it).value());
+            memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
+            std::ispanstream rolesStream(memberRolesList);
+            ++it;
+            auto memberPosList = getValue<std::string_view>((*it).value());
+            memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
+            std::ispanstream posStream(memberPosList);
+
+            std::string memberUri;
+            std::string memberRole;
+            std::string memberPositionString;
+            std::map<int, RelationMember> members;
+            while (std::getline(uriStream, memberUri, ';')) {
+                if (memberUri.empty()) {
+                    throw OsmDataFetcherException("Cannot parse member uri");
+                }
+
+                std::getline(rolesStream, memberRole, ';');
+                std::getline(posStream, memberPositionString, ';');
+
+                int memberPosition;
+                try {
+                    memberPosition = std::stoi(memberPositionString);
+                } catch (std::exception &e) {
+                    std::cerr << e.what() << std::endl;
+                    const std::string msg = "Cannot parse member position: " + memberPositionString;
+                    throw OsmDataFetcherException(msg.c_str());
+                }
+
+                members.emplace(memberPosition, RelationMember(memberUri, memberRole));
+            }
+
+            for (const auto &member : members | std::views::values) {
+                relation.addMember(member);
+            }
+
+            relations.emplace_back(relation);
+        });
+
+        return relations;
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<Way> OsmDataFetcherQLever::fetchWays(const std::set<id_t> &wayIds) {
+        auto response = runQuery(
+            _queryWriter.writeQueryForWaysMembers(wayIds),
+            cnst::PREFIXES_FOR_WAY_MEMBERS);
+
+        std::vector<Way> ways;
+        ways.reserve(wayIds.size());
+
+        forResults(response, [&ways, this](simdjson::ondemand::value results) {
+            auto it = results.begin();
+            auto wayUri = getValue<std::string_view>((*it).value());
+            Way way(OsmObjectHelper::parseIdFromUri(wayUri));
+
+            ++it;
+            auto memberUriList = getValue<std::string_view>((*it).value());
+            memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+            std::ispanstream uriStream(memberUriList);
+            ++it;
+            auto memberPosList = getValue<std::string_view>((*it).value());
+            memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
+            std::ispanstream posStream(memberPosList);
+
+            std::string uri;
+            std::string position;
+            std::map<int, id_t> members;
+            while (std::getline(uriStream, uri, ';')) {
+                if (uri.empty()) { continue; }
+
+                std::getline(posStream, position, ';');
+                id_t memberId = OsmObjectHelper::parseIdFromUri(uri);
+                members.emplace(std::stoi(position), memberId);
+            }
+
+            for (const auto &member : members | std::views::values) {
+                way.addMember(member);
+            }
+
+            ways.emplace_back(way);
+        });
+
+        return ways;
+    }
+
+    // _____________________________________________________________________________________________
+    void OsmDataFetcherQLever::fetchWayInfos(Way &way) {
+        const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_WAY,
+                                                           std::to_string(way.getId()));
+        const auto response = runQuery(
+            _queryWriter.writeQueryForTagsAndMetaInfo(subject),
+            cnst::PREFIXES_FOR_WAY_TAGS_AND_META_INFO);
+
+        forResults(response, [&way, this](simdjson::ondemand::value results) {
+            size_t counter = 0;
+            std::string key;
+            for (auto result: results) {
+                if (result.is_null()) {
+                    counter++;
+                    continue;
+                }
+
+                switch (counter) {
+                    case 0: {
+                        key = getValue<std::string>(result.value());
+                        break;
+                    }
+                    case 1: {
+                        auto value = getValue<std::string>(result.value());
+                        way.addTag(util::XmlHelper::parseKeyName(key),
+                                   util::XmlHelper::parseRdfString<std::string>(value));
+                        break;
+                    }
+                    case 2: {
+                        auto timestamp = getValue<std::string>(result.value());
+                        way.setTimestamp(util::XmlHelper::parseRdfString<std::string>(timestamp));
+                        break;
+                    }
+                    case 3: {
+                        const auto version = getValue<std::string>(result.value());
+                        way.setVersion(util::XmlHelper::parseRdfString<int>(version));
+                        break;
+                    }
+                    case 4: {
+                        const auto changesetId = getValue<std::string>(result.value());
+                        way.setChangesetId(util::XmlHelper::parseRdfString<int>(changesetId));
+                        break;
+                    }
+                    default:
+                        const std::string msg = "Cannot parse way info: "
+                                                + std::string(result.raw_json().value());
+                        throw OsmDataFetcherException(msg.c_str());
+                }
+
+                counter++;
+            }
+        });
+    }
+
+    // _____________________________________________________________________________________________
+    void OsmDataFetcherQLever::fetchRelationInfos(Relation &relation) {
+        const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_REL,
+                                                           std::to_string(relation.getId()));
+        const auto response = runQuery(
+            _queryWriter.writeQueryForTagsAndMetaInfo(subject),
+            cnst::PREFIXES_FOR_RELATION_TAGS_AND_META_INFO);
+
+        forResults(response, [&relation, this](simdjson::ondemand::value results) {
+            size_t counter = 0;
+            std::string key;
+            for (auto result: results) {
+                if (result.is_null()) {
+                    counter++;
+                    continue;
+                }
+
+                switch (counter) {
+                    case 0: {
+                        key = getValue<std::string>(result.value());
+                        break;
+                    }
+                    case 1: {
+                        auto value = getValue<std::string>(result.value());
+                        relation.addTag(util::XmlHelper::parseKeyName(key),
+                                        util::XmlHelper::parseRdfString<std::string>(value));
+                        break;
+                    }
+                    case 2: {
+                        auto timestamp = getValue<std::string>(result.value());
+                        relation.setTimestamp(util::XmlHelper::parseRdfString<std::string>(timestamp));
+                        break;
+                    }
+                    case 3: {
+                        const auto version = getValue<std::string>(result.value());
+                        relation.setVersion(util::XmlHelper::parseRdfString<int>(version));
+                        break;
+                    }
+                    case 4: {
+                        const auto changesetId = getValue<std::string>(result.value());
+                        relation.setChangesetId(util::XmlHelper::parseRdfString<int>(changesetId));
+                        break;
+                    }
+                    default:
+                        const std::string msg = "Cannot parse way info: "
+                                                + std::string(result.raw_json().value());
+                        throw OsmDataFetcherException(msg.c_str());
+                }
+
+                counter++;
+            }
+        });
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<id_t> OsmDataFetcherQLever::fetchWaysMembers(const std::set<id_t> &wayIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForReferencedNodes(wayIds),
+            cnst::PREFIXES_FOR_WAY_MEMBERS);
+
+        std::vector<id_t> nodeIds;
+        forResults(response, [&nodeIds, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto nodeUri = getValue<std::string_view>(result.value());
+                nodeIds.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri));
+            }
+        });
+
+        return nodeIds;
+    }
+
+// _________________________________________________________________________________________________
+std::vector<std::pair<id_t, member_ids_t>>
+olu::osm::OsmDataFetcherQLever::fetchWaysMembersSorted(const std::set<id_t> &wayIds) {
+    const auto response = runQuery(
+        _queryWriter.writeQueryForWaysMembers(wayIds),
+        cnst::PREFIXES_FOR_WAY_MEMBERS);
+
+    std::vector<std::pair<id_t, member_ids_t>> waysWithMembers;
+    waysWithMembers.reserve(wayIds.size());
+
+    forResults(response, [&waysWithMembers, this](simdjson::ondemand::value results) {
+        auto it = results.begin();
+        const auto wayUri = getValue<std::string_view>((*it).value());
+        id_t wayId = OsmObjectHelper::parseIdFromUri(wayUri);
+
+        ++it;
+        const auto memberUriList = getValue<std::string_view>((*it).value());
+        member_ids_t memberIds = parseValueList<id_t>(memberUriList,
+                                                      [](const std::string &uri) {
+                                                          return
+                                                                  OsmObjectHelper::parseIdFromUri(
+                                                                      uri);
+                                                      });
+
+        ++it;
+        auto memberPositionsList = getValue<std::string_view>((*it).value());
+        memberPositionsList = memberPositionsList.substr(1, memberPositionsList.size() - 2);
+        std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
+            [](const std::string &pos) {
+                return stoi(pos);
+            });
+
+        // The list of members that the sparql endpoint returns is not necessarily sorted, so
+        // we have to sort them by their position
+        std::vector<std::pair<int, int>> paired;
+        for (size_t i = 0; i < memberIds.size(); ++i) {
+            paired.emplace_back(memberPositions[i], memberIds[i]);
+        }
+
+        std::ranges::sort(paired);
+
+        for (size_t i = 0; i < memberIds.size(); ++i) {
+            memberIds[i] = paired[i].second;
+        }
+
+        waysWithMembers.emplace_back(wayId, memberIds);
+    });
+
+    return waysWithMembers;
+}
+
+    // _____________________________________________________________________________________________
+    std::vector<std::pair<id_t, std::vector<RelationMember>>>
+    OsmDataFetcherQLever::fetchRelsMembersSorted(const std::set<id_t> &relIds) {
+        const auto response = runQuery(_queryWriter.writeQueryForRelsMembers(relIds),
+                                       cnst::PREFIXES_FOR_RELATION_MEMBERS);
+
+        std::vector<std::pair<id_t, std::vector<RelationMember>>> relsWithMembers;
+        relsWithMembers.reserve(relIds.size());
+
+        forResults(response, [&relsWithMembers, this](simdjson::ondemand::value results) {
+            auto it = results.begin();
+            auto relUri = getValue<std::string_view>((*it).value());
+            id_t relId = OsmObjectHelper::parseIdFromUri(relUri);
+
+            ++it;
+            auto memberUriList = getValue<std::string_view>((*it).value());
+            memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+            member_ids_t memberIds = parseValueList<id_t>(memberUriList,
+                                                          [](const std::string &uri) {
+                                                              return OsmObjectHelper::parseIdFromUri(uri);
+                                                          });
+            std::vector<OsmObjectType> memberTypes = parseValueList<OsmObjectType>(memberUriList,
+                [](const std::string &uri) {
+                    return OsmObjectHelper::parseOsmTypeFromUri(uri);
+                });
+
+            ++it;
+            auto memberPositionsList = getValue<std::string_view>((*it).value());
+            memberPositionsList = memberPositionsList.substr(1, memberPositionsList.size() - 2);
+            std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
+                [](const std::string &pos) {
+                    return stoi(pos);
+                });
+
+            ++it;
+            auto memberRolesList = getValue<std::string_view>((*it).value());
+            memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
+            std::vector<std::string> memberRoles = parseValueList<std::string>(memberRolesList,
+                [](const std::string &pos) {
+                    return pos;
+                });
+
+            std::vector<std::pair<int, RelationMember>> paired;
+            for (size_t i = 0; i < memberIds.size(); ++i) {
+                paired.emplace_back(memberPositions[i],
+                                    RelationMember(memberIds[i], memberTypes[i], memberRoles[i]));
+            }
+
+            // Sort by position
+            std::ranges::sort(paired, [](const auto& a, const auto& b) {
+                return a.first < b.first;
+            });
+
+            std::vector<RelationMember> sortedMembers;
+            for (const auto &member: paired | std::views::values) {
+                sortedMembers.push_back(member);
+            }
+
+            relsWithMembers.emplace_back(relId, sortedMembers);
+        });
+
+        return relsWithMembers;
+    }
+
+    // _____________________________________________________________________________________________
+    std::pair<std::vector<id_t>, std::vector<id_t>>
+    OsmDataFetcherQLever::fetchRelationMembers(const std::set<id_t> &relIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForRelationMemberIds(relIds),
+            cnst::PREFIXES_FOR_RELATION_MEMBERS);
+
+        std::vector<id_t> nodeIds;
+        std::vector<id_t> wayIds;
+        forResults(response, [&nodeIds, &wayIds, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto memberUri = getValue<std::string_view>(result.value());
+                id_t memberId = OsmObjectHelper::parseIdFromUri(memberUri);
+                if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
+                    nodeIds.emplace_back(memberId);
+                } else if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
+                    wayIds.emplace_back(memberId);
+                }
+            }
+        });
+
+        return { nodeIds, wayIds };
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<id_t> OsmDataFetcherQLever::fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForWaysReferencingNodes(nodeIds),
+            cnst::PREFIXES_FOR_WAYS_REFERENCING_NODE);
+
+        std::vector<id_t> memberSubjects;
+        forResults(response, [&memberSubjects, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto memberUri = getValue<std::string_view>(result.value());
+                memberSubjects.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+            }
+        });
+
+        return memberSubjects;
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<id_t>
+    OsmDataFetcherQLever::fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForRelationsReferencingNodes(nodeIds),
+            cnst::PREFIXES_FOR_RELATIONS_REFERENCING_NODE);
+
+        std::vector<id_t> relationIds;
+        forResults(response, [&relationIds, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto memberUri = getValue<std::string_view>(result.value());
+                relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+            }
+        });
+
+        return relationIds;
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<id_t> OsmDataFetcherQLever::fetchRelationsReferencingWays(const std::set<id_t> &wayIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForRelationsReferencingWays(wayIds),
+            cnst::PREFIXES_FOR_RELATIONS_REFERENCING_WAY);
+
+        std::vector<id_t> relationIds;
+        forResults(response, [&relationIds, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto memberUri = getValue<std::string_view>(result.value());
+                relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+            }
+        });
+
+        return relationIds;
+    }
+
+    // _____________________________________________________________________________________________
+    std::vector<id_t>
+    OsmDataFetcherQLever::fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) {
+        const auto response = runQuery(
+            _queryWriter.writeQueryForRelationsReferencingRelations(relationIds),
+            cnst::PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS);
+
+        std::vector<id_t> refRelIds;
+        forResults(response, [&refRelIds, this](simdjson::ondemand::value results) {
+            for (auto result: results) {
+                auto memberUri = getValue<std::string_view>(result.value());
+                refRelIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+            }
+        });
+
+        return refRelIds;
+    }
+}
+
+// _________________________________________________________________________________________________
+template <typename T> std::vector<T>
+olu::osm::OsmDataFetcherQLever::parseValueList(const std::string_view &list,
+                                         const std::function<T(std::string)> function) {
+    std::vector<T> items;
+    std::ispanstream stream(list);
+
+    std::string token;
+    while (std::getline(stream, token, ';')) {
+        items.push_back(function(token));
+    }
+
+    return items;
+}
+
+void
+olu::osm::OsmDataFetcherQLever::forResults(const simdjson::padded_string &response,
+                                           const std::function<void(simdjson::ondemand::value)> func) {
+    auto doc = _parser.iterate(response);
+    if (doc.error()) {
+        std::cerr << doc.error() << std::endl;
+        throw OsmDataFetcherException("Error while parsing response document.");
+    }
+
+    for (auto result : getResults(doc.value())) {
+        if (result.error()) {
+            std::cerr << result.error() << std::endl;
+            throw OsmDataFetcherException("Error while parsing results.");
+        }
+
+        func(result.value());
+    }
+}
+
+// _________________________________________________________________________________________________
+simdjson::ondemand::value
+olu::osm::OsmDataFetcherQLever::getResults(simdjson::ondemand::document &doc) {
+    auto results = doc[cnst::KEY_QLEVER_RESULTS];
+    if (results.error()) {
+        std::cerr << results.error() << std::endl;
+        throw OsmDataFetcherException("Error while getting results from document.");
+    }
+
+    return results.value();
+}
+
+// _________________________________________________________________________________________________
+template <typename T> T
+olu::osm::OsmDataFetcherQLever::getValue(simdjson::ondemand::value value) {
+    try {
+        if constexpr (std::is_same_v<T, std::string_view>) {
+            return value.get_string();
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            return std::string(value.get_string().value());
+        } else if constexpr (std::is_same_v<T, int>) {
+            const auto intString = std::string(value.get_string().value());
+            return std::stoi(intString);
+        }
+    } catch (std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        const std::string msg = "Cannot get value for results: "
+                                + std::string(value.raw_json().value());
+        throw OsmDataFetcherException(msg.c_str());
+    }
+
+    throw OsmDataFetcherException("The type of the value is not supported atm.");
+}

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -41,6 +41,8 @@ namespace cnst = olu::config::constants;
 simdjson::padded_string
 olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::runQuery(const std::string &query,
                                                    const std::vector<std::string> &prefixes) {
+    _stats->countQuery();
+
     _sparqlWrapper.setQuery(query);
     _sparqlWrapper.setPrefixes(prefixes);
     return {_sparqlWrapper.runQuery()};
@@ -585,6 +587,10 @@ olu::osm::OsmDataFetcherQLever::forResults(const simdjson::padded_string &respon
 
         func(result.value());
     }
+
+    // for (auto time: doc["time"]) {
+    //     std::cout << time << std::endl;
+    // }
 }
 
 // _________________________________________________________________________________________________

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -38,38 +38,55 @@
 namespace cnst = olu::config::constants;
 
 // _________________________________________________________________________________________________
-simdjson::padded_string
-olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::runQuery(const std::string &query,
-                                                   const std::vector<std::string> &prefixes) {
+void olu::osm::OsmDataFetcherQLever::runQuery(const std::string &query,
+                                              const std::vector<std::string> &prefixes,
+                                              std::function<void(simdjson::ondemand::value)>
+                                              resultFunc) {
     _stats->countQuery();
 
     _sparqlWrapper.setQuery(query);
     _sparqlWrapper.setPrefixes(prefixes);
-    return {_sparqlWrapper.runQuery()};
+
+    const simdjson::padded_string response = _sparqlWrapper.runQuery();
+    for (auto doc = _parser.iterate(response);
+         auto field: doc.get_object()) {
+        if (field.error()) {
+            std::cerr << field.error() << std::endl;
+            throw OsmDataFetcherException("Error while parsing QLever response.");
+        }
+
+        const std::string_view key = field.escaped_key();
+        if (key == cnst::KEY_QLEVER_RESULTS) {
+            for (auto result: field.value()) {
+                resultFunc(result.value());
+            }
+        }
+        if (key == cnst::KEY_QLEVER_TIME) {
+            _stats->logQleverTimingInfoQuery(field.value().get_object());
+        }
+    }
 }
 
 // _________________________________________________________________________________________________
 std::vector<olu::osm::Node>
-olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchNodes(const std::set<id_t> &nodeIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForNodeLocations(nodeIds),
-        cnst::PREFIXES_FOR_NODE_LOCATION);
-
+olu::osm::OsmDataFetcherQLever::fetchNodes(const std::set<id_t> &nodeIds) {
     std::vector<Node> nodes;
     nodes.reserve(nodeIds.size());
 
-    forResults(response, [&nodes](simdjson::ondemand::value results) {
-        auto it = results.begin();
-        const auto nodeUri = getValue<std::string_view>((*it).value());
-        ++it;
-        const auto nodeLocationAsWkt = getValue<std::string_view>((*it).value());
-        nodes.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri), wktPoint_t(nodeLocationAsWkt));
-    });
+    runQuery(_queryWriter.writeQueryForNodeLocations(nodeIds), cnst::PREFIXES_FOR_NODE_LOCATION,
+             [&nodes](simdjson::ondemand::value results) {
+                 auto it = results.begin();
+                 const auto nodeUri = getValue<std::string_view>((*it).value());
+                 ++it;
+                 const auto nodeLocationAsWkt = getValue<std::string_view>((*it).value());
+                 nodes.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri),
+                                    wktPoint_t(nodeLocationAsWkt));
+             });
 
     if (nodes.size() > nodeIds.size()) {
         std::cerr << "The SPARQL endpoint returned " << std::to_string(nodes.size())
-                  << " locations, for " << std::to_string(nodeIds.size())
-                  << " nodes." << std::endl;
+                << " locations, for " << std::to_string(nodeIds.size())
+                << " nodes." << std::endl;
         throw OsmDataFetcherException("Exception while trying to fetch nodes locations");
     }
 
@@ -77,31 +94,28 @@ olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchNodes(const std::set<
 }
 
 // _________________________________________________________________________________________________
-std::string olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchLatestTimestampOfAnyNode() {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForLatestNodeTimestamp(),
-        cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP);
-
+std::string olu::osm::OsmDataFetcherQLever::fetchLatestTimestampOfAnyNode() {
     std::string timestamp;
-    const std::string timestampPath = "$.res[0][0]";
-    if (const auto error = _parser.iterate(response).at_path(timestampPath).get_string(timestamp);
-        error || timestamp.empty()) {
-        std::cerr << "JSON error: " << error << std::endl;
-        throw OsmDataFetcherException("Could not parse latest timestamp of any node from "
-                                      "sparql endpoint");
-    }
+    runQuery(_queryWriter.writeQueryForLatestNodeTimestamp(),
+             cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP,
+             [&timestamp](simdjson::ondemand::value results) {
+                 for (auto value: results) {
+                     // QLever will return the timestamp in rdf syntax, e.g.:
+                     // "\"2025-05-24T19:15:22\"^^<http://www.w3.org/2001/XMLSchema#dateTime>"
+                     auto response = getValue<std::string>(value.value());
+                     const boost::regex expr("\\\"([^\\\"]+)\\\"");
+                     if (boost::smatch match; regex_search(response, match, expr)) {
+                         timestamp = match[1];
+                     } else {
+                         const std::string msg = "Could not extract timestamp from QLever"
+                                                 " response: " + response;
+                         throw OsmDataFetcherException(msg.c_str());
+                     }
+                 }
+             });
 
-    if (_config.isQLever) {
-        // QLever will return the timestamp in a format like:
-        // "\"2025-05-24T19:15:22\"^^<http://www.w3.org/2001/XMLSchema#dateTime>"
-        const boost::regex expr("\\\"([^\\\"]+)\\\"");
-        if (boost::smatch match; regex_search(timestamp, match, expr)) {
-            timestamp = match[1];
-        } else {
-            const std::string msg = "Could not extract timestamp from QLever"
-                                    " response: " + timestamp;
-            throw OsmDataFetcherException(msg.c_str());
-        }
+    if (timestamp.empty()) {
+        throw OsmDataFetcherException("Could not extract timestamp from QLever");
     }
 
     return timestamp;
@@ -110,111 +124,106 @@ std::string olu::osm::OsmDataFetcherQLever::OsmDataFetcherQLever::fetchLatestTim
 // _________________________________________________________________________________________________
 std::vector<olu::osm::Relation>
 olu::osm::OsmDataFetcherQLever::fetchRelations(const std::set<id_t> &relationIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForRelations(relationIds),
-        cnst::PREFIXES_FOR_RELATION_MEMBERS);
-
     std::vector<Relation> relations;
     relations.reserve(relationIds.size());
 
-    forResults(response, [&relations, this](simdjson::ondemand::value results) {
-        auto it = results.begin();
-        auto relationUri = getValue<std::string_view>((*it).value());
-        auto relationId = OsmObjectHelper::parseIdFromUri(relationUri);
-        Relation relation(relationId);
+    runQuery(_queryWriter.writeQueryForRelations(relationIds), cnst::PREFIXES_FOR_RELATION_MEMBERS,
+             [&relations, this](simdjson::ondemand::value results) {
+                 auto it = results.begin();
+                 auto relationUri = getValue<std::string_view>((*it).value());
+                 auto relationId = OsmObjectHelper::parseIdFromUri(relationUri);
+                 Relation relation(relationId);
 
-        ++it;
-        auto relationType = getValue<std::string>((*it).value());
-        relation.setType(util::XmlHelper::parseRdfString<std::string>(relationType));
+                 ++it;
+                 auto relationType = getValue<std::string>((*it).value());
+                 relation.setType(util::XmlHelper::parseRdfString<std::string>(relationType));
 
-        // Extract members for the relation
-        ++it;
-        auto memberUriList = getValue<std::string_view>((*it).value());
-        memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
-        std::ispanstream uriStream(memberUriList);
-        ++it;
-        auto memberRolesList = getValue<std::string_view>((*it).value());
-        memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
-        std::ispanstream rolesStream(memberRolesList);
-        ++it;
-        auto memberPosList = getValue<std::string_view>((*it).value());
-        memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
-        std::ispanstream posStream(memberPosList);
+                 // Extract members for the relation
+                 ++it;
+                 auto memberUriList = getValue<std::string_view>((*it).value());
+                 memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+                 std::ispanstream uriStream(memberUriList);
+                 ++it;
+                 auto memberRolesList = getValue<std::string_view>((*it).value());
+                 memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
+                 std::ispanstream rolesStream(memberRolesList);
+                 ++it;
+                 auto memberPosList = getValue<std::string_view>((*it).value());
+                 memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
+                 std::ispanstream posStream(memberPosList);
 
-        std::string memberUri;
-        std::string memberRole;
-        std::string memberPositionString;
-        std::map<int, RelationMember> members;
-        while (std::getline(uriStream, memberUri, ';')) {
-            if (memberUri.empty()) {
-                throw OsmDataFetcherException("Cannot parse member uri");
-            }
+                 std::string memberUri;
+                 std::string memberRole;
+                 std::string memberPositionString;
+                 std::map<int, RelationMember> members;
+                 while (std::getline(uriStream, memberUri, ';')) {
+                     if (memberUri.empty()) {
+                         throw OsmDataFetcherException("Cannot parse member uri");
+                     }
 
-            std::getline(rolesStream, memberRole, ';');
-            std::getline(posStream, memberPositionString, ';');
+                     std::getline(rolesStream, memberRole, ';');
+                     std::getline(posStream, memberPositionString, ';');
 
-            int memberPosition;
-            try {
-                memberPosition = std::stoi(memberPositionString);
-            } catch (std::exception &e) {
-                std::cerr << e.what() << std::endl;
-                const std::string msg = "Cannot parse member position: " + memberPositionString;
-                throw OsmDataFetcherException(msg.c_str());
-            }
+                     int memberPosition;
+                     try {
+                         memberPosition = std::stoi(memberPositionString);
+                     } catch (std::exception &e) {
+                         std::cerr << e.what() << std::endl;
+                         const std::string msg =
+                                 "Cannot parse member position: " + memberPositionString;
+                         throw OsmDataFetcherException(msg.c_str());
+                     }
 
-            members.emplace(memberPosition, RelationMember(memberUri, memberRole));
-        }
+                     members.emplace(memberPosition, RelationMember(memberUri, memberRole));
+                 }
 
-        for (const auto &member : members | std::views::values) {
-            relation.addMember(member);
-        }
+                 for (const auto &member: members | std::views::values) {
+                     relation.addMember(member);
+                 }
 
-        relations.emplace_back(relation);
-    });
+                 relations.emplace_back(relation);
+             });
 
     return relations;
 }
 
 // _________________________________________________________________________________________________
 std::vector<olu::osm::Way> olu::osm::OsmDataFetcherQLever::fetchWays(const std::set<id_t> &wayIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForWaysMembers(wayIds),
-        cnst::PREFIXES_FOR_WAY_MEMBERS);
-
     std::vector<Way> ways;
     ways.reserve(wayIds.size());
 
-    forResults(response, [&ways, this](simdjson::ondemand::value results) {
-        auto it = results.begin();
-        auto wayUri = getValue<std::string_view>((*it).value());
-        Way way(OsmObjectHelper::parseIdFromUri(wayUri));
+    runQuery(_queryWriter.writeQueryForWaysMembers(wayIds), cnst::PREFIXES_FOR_WAY_MEMBERS,
+             [&ways, this](simdjson::ondemand::value results) {
+                 auto it = results.begin();
+                 auto wayUri = getValue<std::string_view>((*it).value());
+                 Way way(OsmObjectHelper::parseIdFromUri(wayUri));
 
-        ++it;
-        auto memberUriList = getValue<std::string_view>((*it).value());
-        memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
-        std::ispanstream uriStream(memberUriList);
-        ++it;
-        auto memberPosList = getValue<std::string_view>((*it).value());
-        memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
-        std::ispanstream posStream(memberPosList);
+                 ++it;
+                 auto memberUriList = getValue<std::string_view>((*it).value());
+                 memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+                 std::ispanstream uriStream(memberUriList);
+                 ++it;
+                 auto memberPosList = getValue<std::string_view>((*it).value());
+                 memberPosList = memberPosList.substr(1, memberPosList.size() - 2);
+                 std::ispanstream posStream(memberPosList);
 
-        std::string uri;
-        std::string position;
-        std::map<int, id_t> members;
-        while (std::getline(uriStream, uri, ';')) {
-            if (uri.empty()) { continue; }
+                 std::string uri;
+                 std::string position;
+                 std::map<int, id_t> members;
+                 while (std::getline(uriStream, uri, ';')) {
+                     if (uri.empty()) { continue; }
 
-            std::getline(posStream, position, ';');
-            id_t memberId = OsmObjectHelper::parseIdFromUri(uri);
-            members.emplace(std::stoi(position), memberId);
-        }
+                     std::getline(posStream, position, ';');
+                     id_t memberId = OsmObjectHelper::parseIdFromUri(uri);
+                     members.emplace(std::stoi(position), memberId);
+                 }
 
-        for (const auto &member : members | std::views::values) {
-            way.addMember(member);
-        }
+                 for (const auto &member: members | std::views::values) {
+                     way.addMember(member);
+                 }
 
-        ways.emplace_back(way);
-    });
+                 ways.emplace_back(way);
+             });
 
     return ways;
 }
@@ -223,280 +232,276 @@ std::vector<olu::osm::Way> olu::osm::OsmDataFetcherQLever::fetchWays(const std::
 void olu::osm::OsmDataFetcherQLever::fetchWayInfos(Way &way) {
     const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_WAY,
                                                        std::to_string(way.getId()));
-    const auto response = runQuery(
-        _queryWriter.writeQueryForTagsAndMetaInfo(subject),
-        cnst::PREFIXES_FOR_WAY_TAGS_AND_META_INFO);
+    runQuery(_queryWriter.writeQueryForTagsAndMetaInfo(subject),
+             cnst::PREFIXES_FOR_WAY_TAGS_AND_META_INFO,
+             [&way, this](simdjson::ondemand::value results) {
+                 size_t counter = 0;
+                 std::string key;
+                 for (auto result: results) {
+                     if (result.value().is_null()) {
+                         counter++;
+                         continue;
+                     }
 
-    forResults(response, [&way, this](simdjson::ondemand::value results) {
-        size_t counter = 0;
-        std::string key;
-        for (auto result: results) {
-            if (result.is_null()) {
-                counter++;
-                continue;
-            }
+                     switch (counter) {
+                         case 0: {
+                             key = getValue<std::string>(result.value());
+                             break;
+                         }
+                         case 1: {
+                             auto value = getValue<std::string>(result.value());
+                             way.addTag(util::XmlHelper::parseKeyName(key),
+                                        util::XmlHelper::parseRdfString<std::string>(value));
+                             break;
+                         }
+                         case 2: {
+                             auto timestamp = getValue<std::string>(result.value());
+                             way.setTimestamp(
+                                 util::XmlHelper::parseRdfString<std::string>(timestamp));
+                             break;
+                         }
+                         case 3: {
+                             const auto version = getValue<std::string>(result.value());
+                             way.setVersion(util::XmlHelper::parseRdfString<int>(version));
+                             break;
+                         }
+                         case 4: {
+                             const auto changesetId = getValue<std::string>(result.value());
+                             way.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
+                             break;
+                         }
+                         default:
+                             const std::string msg = "Cannot parse way info: "
+                                                     + std::string(
+                                                         result.value().raw_json().value());
+                             throw OsmDataFetcherException(msg.c_str());
+                     }
 
-            switch (counter) {
-                case 0: {
-                    key = getValue<std::string>(result.value());
-                    break;
-                }
-                case 1: {
-                    auto value = getValue<std::string>(result.value());
-                    way.addTag(util::XmlHelper::parseKeyName(key),
-                               util::XmlHelper::parseRdfString<std::string>(value));
-                    break;
-                }
-                case 2: {
-                    auto timestamp = getValue<std::string>(result.value());
-                    way.setTimestamp(util::XmlHelper::parseRdfString<std::string>(timestamp));
-                    break;
-                }
-                case 3: {
-                    const auto version = getValue<std::string>(result.value());
-                    way.setVersion(util::XmlHelper::parseRdfString<int>(version));
-                    break;
-                }
-                case 4: {
-                    const auto changesetId = getValue<std::string>(result.value());
-                    way.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
-                    break;
-                }
-                default:
-                    const std::string msg = "Cannot parse way info: "
-                                            + std::string(result.raw_json().value());
-                    throw OsmDataFetcherException(msg.c_str());
-            }
-
-            counter++;
-        }
-    });
+                     counter++;
+                 }
+             });
 }
 
 // _________________________________________________________________________________________________
 void olu::osm::OsmDataFetcherQLever::fetchRelationInfos(Relation &relation) {
     const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_REL,
                                                        std::to_string(relation.getId()));
-    const auto response = runQuery(
-        _queryWriter.writeQueryForTagsAndMetaInfo(subject),
-        cnst::PREFIXES_FOR_RELATION_TAGS_AND_META_INFO);
+    runQuery(_queryWriter.writeQueryForTagsAndMetaInfo(subject),
+             cnst::PREFIXES_FOR_RELATION_TAGS_AND_META_INFO,
+             [&relation, this](simdjson::ondemand::value results) {
+                 size_t counter = 0;
+                 std::string key;
+                 for (auto result: results) {
+                     if (result.value().is_null()) {
+                         counter++;
+                         continue;
+                     }
 
-    forResults(response, [&relation, this](simdjson::ondemand::value results) {
-        size_t counter = 0;
-        std::string key;
-        for (auto result: results) {
-            if (result.is_null()) {
-                counter++;
-                continue;
-            }
+                     switch (counter) {
+                         case 0: {
+                             key = getValue<std::string>(result.value());
+                             break;
+                         }
+                         case 1: {
+                             auto value = getValue<std::string>(result.value());
+                             relation.addTag(util::XmlHelper::parseKeyName(key),
+                                             util::XmlHelper::parseRdfString<std::string>(value));
+                             break;
+                         }
+                         case 2: {
+                             auto timestamp = getValue<std::string>(result.value());
+                             relation.setTimestamp(
+                                 util::XmlHelper::parseRdfString<std::string>(timestamp));
+                             break;
+                         }
+                         case 3: {
+                             const auto version = getValue<std::string>(result.value());
+                             relation.setVersion(util::XmlHelper::parseRdfString<int>(version));
+                             break;
+                         }
+                         case 4: {
+                             const auto changesetId = getValue<std::string>(result.value());
+                             relation.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
+                             break;
+                         }
+                         default:
+                             const std::string msg = "Cannot parse way info: "
+                                                     + std::string(
+                                                         result.value().raw_json().value());
+                             throw OsmDataFetcherException(msg.c_str());
+                     }
 
-            switch (counter) {
-                case 0: {
-                    key = getValue<std::string>(result.value());
-                    break;
-                }
-                case 1: {
-                    auto value = getValue<std::string>(result.value());
-                    relation.addTag(util::XmlHelper::parseKeyName(key),
-                                    util::XmlHelper::parseRdfString<std::string>(value));
-                    break;
-                }
-                case 2: {
-                    auto timestamp = getValue<std::string>(result.value());
-                    relation.setTimestamp(util::XmlHelper::parseRdfString<std::string>(timestamp));
-                    break;
-                }
-                case 3: {
-                    const auto version = getValue<std::string>(result.value());
-                    relation.setVersion(util::XmlHelper::parseRdfString<int>(version));
-                    break;
-                }
-                case 4: {
-                    const auto changesetId = getValue<std::string>(result.value());
-                    relation.setChangesetId(OsmObjectHelper::parseIdFromUri(changesetId));
-                    break;
-                }
-                default:
-                    const std::string msg = "Cannot parse way info: "
-                                            + std::string(result.raw_json().value());
-                    throw OsmDataFetcherException(msg.c_str());
-            }
-
-            counter++;
-        }
-    });
+                     counter++;
+                 }
+             });
 }
 
 // _________________________________________________________________________________________________
-std::vector<olu::id_t> olu::osm::OsmDataFetcherQLever::fetchWaysMembers(const std::set<id_t> &wayIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForReferencedNodes(wayIds),
-        cnst::PREFIXES_FOR_WAY_MEMBERS);
-
+std::vector<olu::id_t> olu::osm::OsmDataFetcherQLever::fetchWaysMembers(
+    const std::set<id_t> &wayIds) {
     std::vector<id_t> nodeIds;
-    forResults(response, [&nodeIds, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto nodeUri = getValue<std::string_view>(result.value());
-            nodeIds.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri));
-        }
-    });
+    runQuery(_queryWriter.writeQueryForReferencedNodes(wayIds), cnst::PREFIXES_FOR_WAY_MEMBERS,
+             [&nodeIds](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto nodeUri = getValue<std::string_view>(result.value());
+                     nodeIds.emplace_back(OsmObjectHelper::parseIdFromUri(nodeUri));
+                 }
+             });
 
     return nodeIds;
 }
 
 // _________________________________________________________________________________________________
-std::vector<std::pair<olu::id_t, olu::member_ids_t>>
+std::vector<std::pair<olu::id_t, olu::member_ids_t> >
 olu::osm::OsmDataFetcherQLever::fetchWaysMembersSorted(const std::set<id_t> &wayIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForWaysMembers(wayIds),
-        cnst::PREFIXES_FOR_WAY_MEMBERS);
-
-    std::vector<std::pair<id_t, member_ids_t>> waysWithMembers;
+    std::vector<std::pair<id_t, member_ids_t> > waysWithMembers;
     waysWithMembers.reserve(wayIds.size());
 
-    forResults(response, [&waysWithMembers, this](simdjson::ondemand::value results) {
-        auto it = results.begin();
-        const auto wayUri = getValue<std::string_view>((*it).value());
-        id_t wayId = OsmObjectHelper::parseIdFromUri(wayUri);
+    runQuery(_queryWriter.writeQueryForWaysMembers(wayIds), cnst::PREFIXES_FOR_WAY_MEMBERS,
+             [&waysWithMembers, this](simdjson::ondemand::value results) {
+                 auto it = results.begin();
+                 const auto wayUri = getValue<std::string_view>((*it).value());
+                 id_t wayId = OsmObjectHelper::parseIdFromUri(wayUri);
 
-        ++it;
-        const auto memberUriList = getValue<std::string_view>((*it).value());
-        member_ids_t memberIds = parseValueList<id_t>(memberUriList,
-                                                      [](const std::string &uri) {
-                                                          return
-                                                                  OsmObjectHelper::parseIdFromUri(
-                                                                      uri);
-                                                      });
+                 ++it;
+                 const auto memberUriList = getValue<std::string_view>((*it).value());
+                 member_ids_t memberIds = parseValueList<id_t>(memberUriList,
+                                                               [](const std::string &uri) {
+                                                                   return
+                                                                           OsmObjectHelper::parseIdFromUri(
+                                                                               uri);
+                                                               });
 
-        ++it;
-        auto memberPositionsList = getValue<std::string_view>((*it).value());
-        memberPositionsList = memberPositionsList.substr(1, memberPositionsList.size() - 2);
-        std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
-            [](const std::string &pos) {
-                return stoi(pos);
-            });
+                 ++it;
+                 auto memberPositionsList = getValue<std::string_view>((*it).value());
+                 memberPositionsList = memberPositionsList.
+                         substr(1, memberPositionsList.size() - 2);
+                 std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
+                     [](const std::string &pos) {
+                         return stoi(pos);
+                     });
 
-        // The list of members that the sparql endpoint returns is not necessarily sorted, so
-        // we have to sort them by their position
-        std::vector<std::pair<int, int>> paired;
-        for (size_t i = 0; i < memberIds.size(); ++i) {
-            paired.emplace_back(memberPositions[i], memberIds[i]);
-        }
+                 // The list of members that the sparql endpoint returns is not necessarily sorted, so
+                 // we have to sort them by their position
+                 std::vector<std::pair<int, int> > paired;
+                 for (size_t i = 0; i < memberIds.size(); ++i) {
+                     paired.emplace_back(memberPositions[i], memberIds[i]);
+                 }
 
-        std::ranges::sort(paired);
+                 std::ranges::sort(paired);
 
-        for (size_t i = 0; i < memberIds.size(); ++i) {
-            memberIds[i] = paired[i].second;
-        }
+                 for (size_t i = 0; i < memberIds.size(); ++i) {
+                     memberIds[i] = paired[i].second;
+                 }
 
-        waysWithMembers.emplace_back(wayId, memberIds);
-    });
+                 waysWithMembers.emplace_back(wayId, memberIds);
+             });
 
     return waysWithMembers;
 }
 
 // _________________________________________________________________________________________________
-std::vector<std::pair<olu::id_t, std::vector<olu::osm::RelationMember>>>
+std::vector<std::pair<olu::id_t, std::vector<olu::osm::RelationMember> > >
 olu::osm::OsmDataFetcherQLever::fetchRelsMembersSorted(const std::set<id_t> &relIds) {
-    const auto response = runQuery(_queryWriter.writeQueryForRelsMembers(relIds),
-                                   cnst::PREFIXES_FOR_RELATION_MEMBERS);
-
-    std::vector<std::pair<id_t, std::vector<RelationMember>>> relsWithMembers;
+    std::vector<std::pair<id_t, std::vector<RelationMember> > > relsWithMembers;
     relsWithMembers.reserve(relIds.size());
 
-    forResults(response, [&relsWithMembers, this](simdjson::ondemand::value results) {
-        auto it = results.begin();
-        auto relUri = getValue<std::string_view>((*it).value());
-        id_t relId = OsmObjectHelper::parseIdFromUri(relUri);
+    runQuery(_queryWriter.writeQueryForRelsMembers(relIds), cnst::PREFIXES_FOR_RELATION_MEMBERS,
+             [&relsWithMembers, this](simdjson::ondemand::value results) {
+                 auto it = results.begin();
+                 auto relUri = getValue<std::string_view>((*it).value());
+                 id_t relId = OsmObjectHelper::parseIdFromUri(relUri);
 
-        ++it;
-        auto memberUriList = getValue<std::string_view>((*it).value());
-        memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
-        member_ids_t memberIds = parseValueList<id_t>(memberUriList,
-                                                      [](const std::string &uri) {
-                                                          return OsmObjectHelper::parseIdFromUri(uri);
-                                                      });
-        std::vector<OsmObjectType> memberTypes = parseValueList<OsmObjectType>(memberUriList,
-            [](const std::string &uri) {
-                return OsmObjectHelper::parseOsmTypeFromUri(uri);
-            });
+                 ++it;
+                 auto memberUriList = getValue<std::string_view>((*it).value());
+                 memberUriList = memberUriList.substr(1, memberUriList.size() - 2);
+                 member_ids_t memberIds = parseValueList<id_t>(memberUriList,
+                                                               [](const std::string &uri) {
+                                                                   return
+                                                                           OsmObjectHelper::parseIdFromUri(
+                                                                               uri);
+                                                               });
+                 std::vector<OsmObjectType> memberTypes = parseValueList<OsmObjectType>(
+                     memberUriList,
+                     [](const std::string &uri) {
+                         return OsmObjectHelper::parseOsmTypeFromUri(uri);
+                     });
 
-        ++it;
-        auto memberPositionsList = getValue<std::string_view>((*it).value());
-        memberPositionsList = memberPositionsList.substr(1, memberPositionsList.size() - 2);
-        std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
-            [](const std::string &pos) {
-                return stoi(pos);
-            });
+                 ++it;
+                 auto memberPositionsList = getValue<std::string_view>((*it).value());
+                 memberPositionsList = memberPositionsList.
+                         substr(1, memberPositionsList.size() - 2);
+                 std::vector<int> memberPositions = parseValueList<int>(memberPositionsList,
+                     [](const std::string &pos) {
+                         return stoi(pos);
+                     });
 
-        ++it;
-        auto memberRolesList = getValue<std::string_view>((*it).value());
-        memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
-        std::vector<std::string> memberRoles = parseValueList<std::string>(memberRolesList,
-            [](const std::string &pos) {
-                return pos;
-            });
+                 ++it;
+                 auto memberRolesList = getValue<std::string_view>((*it).value());
+                 memberRolesList = memberRolesList.substr(1, memberRolesList.size() - 2);
+                 std::vector<std::string> memberRoles = parseValueList<std::string>(memberRolesList,
+                     [](const std::string &pos) {
+                         return pos;
+                     });
 
-        std::vector<std::pair<int, RelationMember>> paired;
-        for (size_t i = 0; i < memberIds.size(); ++i) {
-            paired.emplace_back(memberPositions[i],
-                                RelationMember(memberIds[i], memberTypes[i], memberRoles[i]));
-        }
+                 std::vector<std::pair<int, RelationMember> > paired;
+                 for (size_t i = 0; i < memberIds.size(); ++i) {
+                     paired.emplace_back(memberPositions[i],
+                                         RelationMember(memberIds[i], memberTypes[i],
+                                                        memberRoles[i]));
+                 }
 
-        // Sort by position
-        std::ranges::sort(paired, [](const auto& a, const auto& b) {
-            return a.first < b.first;
-        });
+                 // Sort by position
+                 std::ranges::sort(paired, [](const auto &a, const auto &b) {
+                     return a.first < b.first;
+                 });
 
-        std::vector<RelationMember> sortedMembers;
-        for (const auto &member: paired | std::views::values) {
-            sortedMembers.push_back(member);
-        }
+                 std::vector<RelationMember> sortedMembers;
+                 for (const auto &member: paired | std::views::values) {
+                     sortedMembers.push_back(member);
+                 }
 
-        relsWithMembers.emplace_back(relId, sortedMembers);
-    });
+                 relsWithMembers.emplace_back(relId, sortedMembers);
+             });
 
     return relsWithMembers;
 }
 
 // _________________________________________________________________________________________________
-std::pair<std::vector<olu::id_t>, std::vector<olu::id_t>>
+std::pair<std::vector<olu::id_t>, std::vector<olu::id_t> >
 olu::osm::OsmDataFetcherQLever::fetchRelationMembers(const std::set<id_t> &relIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForRelationMemberIds(relIds),
-        cnst::PREFIXES_FOR_RELATION_MEMBERS);
-
     std::vector<id_t> nodeIds;
     std::vector<id_t> wayIds;
-    forResults(response, [&nodeIds, &wayIds, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto memberUri = getValue<std::string_view>(result.value());
-            id_t memberId = OsmObjectHelper::parseIdFromUri(memberUri);
-            if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
-                nodeIds.emplace_back(memberId);
-            } else if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
-                wayIds.emplace_back(memberId);
-            }
-        }
-    });
+    runQuery(_queryWriter.writeQueryForRelationMemberIds(relIds),
+             cnst::PREFIXES_FOR_RELATION_MEMBERS,
+             [&nodeIds, &wayIds](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto memberUri = getValue<std::string_view>(result.value());
+                     id_t memberId = OsmObjectHelper::parseIdFromUri(memberUri);
+                     if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_NODE)) {
+                         nodeIds.emplace_back(memberId);
+                     } else if (memberUri.starts_with(cnst::NAMESPACE_IRI_OSM_WAY)) {
+                         wayIds.emplace_back(memberId);
+                     }
+                 }
+             });
 
-    return { nodeIds, wayIds };
+    return {nodeIds, wayIds};
 }
 
 // _________________________________________________________________________________________________
 std::vector<olu::id_t>
 olu::osm::OsmDataFetcherQLever::fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForWaysReferencingNodes(nodeIds),
-        cnst::PREFIXES_FOR_WAYS_REFERENCING_NODE);
-
     std::vector<id_t> memberSubjects;
-    forResults(response, [&memberSubjects, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto memberUri = getValue<std::string_view>(result.value());
-            memberSubjects.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
-        }
-    });
+
+    runQuery(_queryWriter.writeQueryForWaysReferencingNodes(nodeIds),
+             cnst::PREFIXES_FOR_WAYS_REFERENCING_NODE,
+             [&memberSubjects, this](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto memberUri = getValue<std::string_view>(result.value());
+                     memberSubjects.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+                 }
+             });
 
     return memberSubjects;
 }
@@ -504,17 +509,15 @@ olu::osm::OsmDataFetcherQLever::fetchWaysReferencingNodes(const std::set<id_t> &
 // _________________________________________________________________________________________________
 std::vector<olu::id_t>
 olu::osm::OsmDataFetcherQLever::fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForRelationsReferencingNodes(nodeIds),
-        cnst::PREFIXES_FOR_RELATIONS_REFERENCING_NODE);
-
     std::vector<id_t> relationIds;
-    forResults(response, [&relationIds, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto memberUri = getValue<std::string_view>(result.value());
-            relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
-        }
-    });
+    runQuery(_queryWriter.writeQueryForRelationsReferencingNodes(nodeIds),
+             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_NODE,
+             [&relationIds, this](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto memberUri = getValue<std::string_view>(result.value());
+                     relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+                 }
+             });
 
     return relationIds;
 }
@@ -522,41 +525,39 @@ olu::osm::OsmDataFetcherQLever::fetchRelationsReferencingNodes(const std::set<id
 // _________________________________________________________________________________________________
 std::vector<olu::id_t>
 olu::osm::OsmDataFetcherQLever::fetchRelationsReferencingWays(const std::set<id_t> &wayIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForRelationsReferencingWays(wayIds),
-        cnst::PREFIXES_FOR_RELATIONS_REFERENCING_WAY);
-
     std::vector<id_t> relationIds;
-    forResults(response, [&relationIds, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto memberUri = getValue<std::string_view>(result.value());
-            relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
-        }
-    });
+    runQuery(_queryWriter.writeQueryForRelationsReferencingWays(wayIds),
+             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_WAY,
+             [&relationIds, this](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto memberUri = getValue<std::string_view>(result.value());
+                     relationIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+                 }
+             });
 
     return relationIds;
 }
 
 // _________________________________________________________________________________________________
 std::vector<olu::id_t>
-olu::osm::OsmDataFetcherQLever::fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) {
-    const auto response = runQuery(
-        _queryWriter.writeQueryForRelationsReferencingRelations(relationIds),
-        cnst::PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS);
-
+olu::osm::OsmDataFetcherQLever::fetchRelationsReferencingRelations(
+    const std::set<id_t> &relationIds) {
     std::vector<id_t> refRelIds;
-    forResults(response, [&refRelIds, this](simdjson::ondemand::value results) {
-        for (auto result: results) {
-            auto memberUri = getValue<std::string_view>(result.value());
-            refRelIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
-        }
-    });
+    runQuery(_queryWriter.writeQueryForRelationsReferencingRelations(relationIds),
+             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS,
+             [&refRelIds, this](simdjson::ondemand::value results) {
+                 for (auto result: results) {
+                     auto memberUri = getValue<std::string_view>(result.value());
+                     refRelIds.emplace_back(OsmObjectHelper::parseIdFromUri(memberUri));
+                 }
+             });
 
     return refRelIds;
 }
 
 // _________________________________________________________________________________________________
-template <typename T> std::vector<T>
+template<typename T>
+std::vector<T>
 olu::osm::OsmDataFetcherQLever::parseValueList(const std::string_view &list,
                                                const std::function<T(std::string)> function) {
     std::vector<T> items;
@@ -572,14 +573,15 @@ olu::osm::OsmDataFetcherQLever::parseValueList(const std::string_view &list,
 
 void
 olu::osm::OsmDataFetcherQLever::forResults(const simdjson::padded_string &response,
-                                           const std::function<void(simdjson::ondemand::value)> func) {
+                                           const std::function<void(simdjson::ondemand::value)>
+                                           func) {
     auto doc = _parser.iterate(response);
     if (doc.error()) {
         std::cerr << doc.error() << std::endl;
         throw OsmDataFetcherException("Error while parsing response document.");
     }
 
-    for (auto result : getResults(doc.value())) {
+    for (auto result: getResults(doc.value())) {
         if (result.error()) {
             std::cerr << result.error() << std::endl;
             throw OsmDataFetcherException("Error while parsing results.");
@@ -587,10 +589,6 @@ olu::osm::OsmDataFetcherQLever::forResults(const simdjson::padded_string &respon
 
         func(result.value());
     }
-
-    // for (auto time: doc["time"]) {
-    //     std::cout << time << std::endl;
-    // }
 }
 
 // _________________________________________________________________________________________________
@@ -606,7 +604,8 @@ olu::osm::OsmDataFetcherQLever::getResults(simdjson::ondemand::document &doc) {
 }
 
 // _________________________________________________________________________________________________
-template <typename T> T
+template<typename T>
+T
 olu::osm::OsmDataFetcherQLever::getValue(simdjson::ondemand::value value) {
     try {
         if constexpr (std::is_same_v<T, std::string_view>) {

--- a/src/osm/OsmDataFetcherSparql.cpp
+++ b/src/osm/OsmDataFetcherSparql.cpp
@@ -39,6 +39,8 @@ namespace cnst = olu::config::constants;
 simdjson::padded_string
 olu::osm::OsmDataFetcherSparql::runQuery(const std::string &query,
                                                                const std::vector<std::string> &prefixes) {
+    _stats->countQuery();
+
     _sparqlWrapper.setQuery(query);
     _sparqlWrapper.setPrefixes(prefixes);
     return {_sparqlWrapper.runQuery()};

--- a/src/osm/OsmDataFetcherSparql.cpp
+++ b/src/osm/OsmDataFetcherSparql.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024, University of Freiburg
+// Copyright 2025, University of Freiburg
 // Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
 
 // This file is part of osm-live-updates.
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "osm/OsmDataFetcher.h"
+#include "osm/OsmDataFetcherSparql.h"
 
 #include <vector>
 #include <iostream>
@@ -37,8 +37,8 @@ namespace cnst = olu::config::constants;
 
 // _________________________________________________________________________________________________
 simdjson::padded_string
-olu::osm::OsmDataFetcher::OsmDataFetcher::runQuery(const std::string &query,
-                                                   const std::vector<std::string> &prefixes) {
+olu::osm::OsmDataFetcherSparql::runQuery(const std::string &query,
+                                                               const std::vector<std::string> &prefixes) {
     _sparqlWrapper.setQuery(query);
     _sparqlWrapper.setPrefixes(prefixes);
     return {_sparqlWrapper.runQuery()};
@@ -46,7 +46,7 @@ olu::osm::OsmDataFetcher::OsmDataFetcher::runQuery(const std::string &query,
 
 // _________________________________________________________________________________________________
 std::vector<olu::osm::Node>
-olu::osm::OsmDataFetcher::OsmDataFetcher::fetchNodes(const std::set<id_t> &nodeIds) {
+olu::osm::OsmDataFetcherSparql::fetchNodes(const std::set<id_t> &nodeIds) {
     const auto response = runQuery(
         _queryWriter.writeQueryForNodeLocations(nodeIds),
         cnst::PREFIXES_FOR_NODE_LOCATION);
@@ -71,7 +71,7 @@ olu::osm::OsmDataFetcher::OsmDataFetcher::fetchNodes(const std::set<id_t> &nodeI
 }
 
 // _________________________________________________________________________________________________
-std::string olu::osm::OsmDataFetcher::OsmDataFetcher::fetchLatestTimestampOfAnyNode() {
+std::string olu::osm::OsmDataFetcherSparql::fetchLatestTimestampOfAnyNode() {
     const auto response = runQuery(
         _queryWriter.writeQueryForLatestNodeTimestamp(),
         cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP);
@@ -91,7 +91,7 @@ std::string olu::osm::OsmDataFetcher::OsmDataFetcher::fetchLatestTimestampOfAnyN
 namespace olu::osm {
     // _____________________________________________________________________________________________
     std::vector<Relation>
-    OsmDataFetcher::fetchRelations(const std::set<id_t> &relationIds) {
+    OsmDataFetcherSparql::fetchRelations(const std::set<id_t> &relationIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForRelations(relationIds),
             cnst::PREFIXES_FOR_RELATION_MEMBERS);
@@ -152,7 +152,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    std::vector<Way> OsmDataFetcher::fetchWays(const std::set<id_t> &wayIds) {
+    std::vector<Way> OsmDataFetcherSparql::fetchWays(const std::set<id_t> &wayIds) {
         auto response = runQuery(
             _queryWriter.writeQueryForWaysMembers(wayIds),
             cnst::PREFIXES_FOR_WAY_MEMBERS);
@@ -191,7 +191,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    void OsmDataFetcher::fetchWayInfos(Way &way) {
+    void OsmDataFetcherSparql::fetchWayInfos(Way &way) {
         const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_WAY,
                                                            std::to_string(way.getId()));
         const auto response = runQuery(
@@ -218,7 +218,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    void OsmDataFetcher::fetchRelationInfos(Relation &relation) {
+    void OsmDataFetcherSparql::fetchRelationInfos(Relation &relation) {
         const std::string subject = cnst::MakePrefixedName(cnst::NAMESPACE_OSM_REL,
                                                            std::to_string(relation.getId()));
         const auto response = runQuery(
@@ -245,7 +245,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    std::vector<id_t> OsmDataFetcher::fetchWaysMembers(const std::set<id_t> &wayIds) {
+    std::vector<id_t> OsmDataFetcherSparql::fetchWaysMembers(const std::set<id_t> &wayIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForReferencedNodes(wayIds),
             cnst::PREFIXES_FOR_WAY_MEMBERS);
@@ -261,7 +261,7 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     std::vector<std::pair<id_t, member_ids_t>>
-    OsmDataFetcher::fetchWaysMembersSorted(const std::set<id_t> &wayIds) {
+    OsmDataFetcherSparql::fetchWaysMembersSorted(const std::set<id_t> &wayIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForWaysMembers(wayIds),
             cnst::PREFIXES_FOR_WAY_MEMBERS);
@@ -306,7 +306,7 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     std::vector<std::pair<id_t, std::vector<RelationMember>>>
-    OsmDataFetcher::fetchRelsMembersSorted(const std::set<id_t> &relIds) {
+    OsmDataFetcherSparql::fetchRelsMembersSorted(const std::set<id_t> &relIds) {
         const auto response = runQuery(_queryWriter.writeQueryForRelsMembers(relIds),
                                        cnst::PREFIXES_FOR_RELATION_MEMBERS);
 
@@ -363,7 +363,7 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     std::pair<std::vector<id_t>, std::vector<id_t>>
-    OsmDataFetcher::fetchRelationMembers(const std::set<id_t> &relIds) {
+    OsmDataFetcherSparql::fetchRelationMembers(const std::set<id_t> &relIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForRelationMemberIds(relIds),
             cnst::PREFIXES_FOR_RELATION_MEMBERS);
@@ -385,7 +385,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    std::vector<id_t> OsmDataFetcher::fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) {
+    std::vector<id_t> OsmDataFetcherSparql::fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForWaysReferencingNodes(nodeIds),
             cnst::PREFIXES_FOR_WAYS_REFERENCING_NODE);
@@ -401,7 +401,7 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     std::vector<id_t>
-    OsmDataFetcher::fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) {
+    OsmDataFetcherSparql::fetchRelationsReferencingNodes(const std::set<id_t> &nodeIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForRelationsReferencingNodes(nodeIds),
             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_NODE);
@@ -416,7 +416,7 @@ namespace olu::osm {
     }
 
     // _____________________________________________________________________________________________
-    std::vector<id_t> OsmDataFetcher::fetchRelationsReferencingWays(const std::set<id_t> &wayIds) {
+    std::vector<id_t> OsmDataFetcherSparql::fetchRelationsReferencingWays(const std::set<id_t> &wayIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForRelationsReferencingWays(wayIds),
             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_WAY);
@@ -432,7 +432,7 @@ namespace olu::osm {
 
     // _____________________________________________________________________________________________
     std::vector<id_t>
-    OsmDataFetcher::fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) {
+    OsmDataFetcherSparql::fetchRelationsReferencingRelations(const std::set<id_t> &relationIds) {
         const auto response = runQuery(
             _queryWriter.writeQueryForRelationsReferencingRelations(relationIds),
             cnst::PREFIXES_FOR_RELATIONS_REFERENCING_RELATIONS);
@@ -449,7 +449,7 @@ namespace olu::osm {
 
 // _________________________________________________________________________________________________
 template <typename T> std::vector<T>
-olu::osm::OsmDataFetcher::parseValueList(const std::string_view &list,
+olu::osm::OsmDataFetcherSparql::parseValueList(const std::string_view &list,
                                          const std::function<T(std::string)> function) {
     std::vector<T> items;
     std::ispanstream stream(list);
@@ -463,16 +463,16 @@ olu::osm::OsmDataFetcher::parseValueList(const std::string_view &list,
 }
 
 // _________________________________________________________________________________________________
-simdjson::simdjson_result<simdjson::westmere::ondemand::value>
-olu::osm::OsmDataFetcher::getBindings(
+simdjson::simdjson_result<simdjson::ondemand::value>
+olu::osm::OsmDataFetcherSparql::getBindings(
     simdjson::simdjson_result<simdjson::ondemand::document> &doc) {
     return doc[config::constants::KEY_RESULTS][config::constants::KEY_BINDINGS];
 }
 
 // _________________________________________________________________________________________________
 template <typename T> T
-olu::osm::OsmDataFetcher::getValue(
-    simdjson::simdjson_result<simdjson::westmere::ondemand::value> value) {
+olu::osm::OsmDataFetcherSparql::getValue(
+    simdjson::simdjson_result<simdjson::ondemand::value> value) {
     try {
         if constexpr (std::is_same_v<T, std::string_view>) {
             return value[config::constants::KEY_VALUE].get_string();

--- a/src/osm/OsmObjectHelper.cpp
+++ b/src/osm/OsmObjectHelper.cpp
@@ -34,6 +34,16 @@ olu::id_t olu::osm::OsmObjectHelper::parseIdFromUri(const std::string_view &uri)
     std::vector<char> id;
     // Read characters from the end of the uri until the first non digit is reached
     for (auto it = uri.rbegin(); it != uri.rend(); ++it) {
+        // Uris can be inside angle brackets, e.g., <https://www.openstreetmap.org/node/1>
+        if (*it == '>') {
+            continue;
+        }
+
+        // Uris can also be in quotes, e.g., "<https://www.openstreetmap.org/node/1>"
+        if (*it == '\"') {
+            continue;
+        }
+
         if (std::isdigit(*it)) {
             id.push_back(*it);
         } else {

--- a/src/osm/OsmReplicationServerHelper.cpp
+++ b/src/osm/OsmReplicationServerHelper.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "omp.h"
 #include "boost/regex.hpp"
 
 #include "config/Constants.h"
@@ -29,6 +30,8 @@
 #include "util/HttpRequest.h"
 
 namespace cnst = olu::config::constants;
+
+inline constexpr int BATCH_SIZE = 100;
 
 // _________________________________________________________________________________________________
 olu::osm::OsmDatabaseState
@@ -110,29 +113,65 @@ olu::osm::OsmDatabaseState
 olu::osm::OsmReplicationServerHelper::fetchDatabaseStateForTimestamp(
     const std::string& timeStamp) const {
     // We start with the latest state file on the replication server
-    OsmDatabaseState state = fetchLatestDatabaseState();
-    while (true) {
-        // We have found a state file at which we have to start if the timestamp from the state
-        // file is further in the past than the latest timestamp from the sparql endpoint.
-        // (We can lexicographically compare timestamps because they are ISO-formatted
-        // "YYYY-MM-DDTHH:MM:SS")
-        if (state.timeStamp <= timeStamp) {
-            return state;
+    OsmDatabaseState latestState = fetchLatestDatabaseState();
+    // We have found a state file at which we have to start if the timestamp from the state
+    // file is further in the past than the latest timestamp from the sparql endpoint.
+    // (We can lexicographically compare timestamps because they are ISO-formatted
+    // "YYYY-MM-DDTHH:MM:SS")
+    if (latestState.timeStamp <= timeStamp) {
+        return latestState;
+    }
+
+    // Fetch database states in batches of BATCH_SIZE until we find a state file that has a matching
+    // timestamp.
+    auto toSeqNum = latestState.sequenceNumber;
+    while (toSeqNum > 0) {
+        const auto fromSeqNum = std::max(toSeqNum - BATCH_SIZE, 0);
+
+        for (auto databaseStates = fetchDatabaseStatesForSequenceNumbers(fromSeqNum, toSeqNum);
+             auto fetchedState : databaseStates) {
+            if (fetchedState.timeStamp <= timeStamp) {
+                return fetchedState;
+            }
         }
 
-        auto sequenceNumber = state.sequenceNumber;
-        sequenceNumber--;
+        toSeqNum = std::max(fromSeqNum, 0);
+    }
 
+    const std::string msg = "Could not find matching database state for timestamp: " + timeStamp;
+    throw OsmReplicationServerHelperException(msg.c_str());
+}
+
+// _________________________________________________________________________________________________
+std::vector<olu::osm::OsmDatabaseState>
+olu::osm::OsmReplicationServerHelper::fetchDatabaseStatesForSequenceNumbers(const int fromSeqNum,
+    const int toSeqNum) const {
+    std::vector<OsmDatabaseState> states;
+#pragma omp parallel for
+    for (int seqNum = fromSeqNum; seqNum <= toSeqNum; seqNum++) {
+        OsmDatabaseState state;
         try {
-            // Try the next older database state next
-            state = fetchDatabaseStateForSeqNumber(sequenceNumber);
+            state = fetchDatabaseStateForSeqNumber(seqNum);
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
-            const std::string msg = "Exception while trying to determine database state "
-                                    "for timestamp: " + timeStamp;
+            const std::string msg = "Exception while trying to fetch state file for sequence "
+                                    "number: " + std::to_string(seqNum);
             throw OsmReplicationServerHelperException(msg.c_str());
         }
+
+#pragma omp critical
+        {
+            states.push_back(state);
+        }
     }
+
+    // Since we fetched the states in parallel, we have to sort them by sequence number to make sure
+    // they are in the correct order.
+    std::ranges::sort(states, [](const OsmDatabaseState& a, const OsmDatabaseState& b) {
+        return a.sequenceNumber > b.sequenceNumber;
+    });
+
+    return states;
 }
 
 // _________________________________________________________________________________________________

--- a/src/osm/OsmReplicationServerHelper.cpp
+++ b/src/osm/OsmReplicationServerHelper.cpp
@@ -31,7 +31,7 @@
 
 namespace cnst = olu::config::constants;
 
-inline constexpr int BATCH_SIZE = 100;
+inline constexpr int BATCH_SIZE = 10;
 
 // _________________________________________________________________________________________________
 olu::osm::OsmDatabaseState

--- a/src/osm/OsmUpdater.cpp
+++ b/src/osm/OsmUpdater.cpp
@@ -121,7 +121,7 @@ void olu::osm::OsmUpdater::run() {
         _stats.endTimeMergingChangeFiles();
 
         _stats.printCurrentStep("Process changes from "
-                                + std::to_string(_latestState.sequenceNumber - sequenceNumber)
+                                + std::to_string(_latestState.sequenceNumber - sequenceNumber + 1)
                                 + " change files...");
 
         auto och{OsmChangeHandler(_config, *_odf, _stats)};

--- a/src/osm/OsmUpdater.cpp
+++ b/src/osm/OsmUpdater.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <osm/OsmDataFetcherQLever.h>
 #include <osm/OsmDataFetcherSparql.h>
 
 #include "osmium/visitor.hpp"
@@ -42,11 +43,19 @@
 
 namespace cnst = olu::config::constants;
 
+std::unique_ptr<olu::osm::OsmDataFetcher> createOsmDataFetcher(const olu::config::Config& config) {
+    if (config.isQLever) {
+        return std::make_unique<olu::osm::OsmDataFetcherQLever>(config);
+    }
+
+    return std::make_unique<olu::osm::OsmDataFetcherSparql>(config);
+}
+
 // _________________________________________________________________________________________________
 olu::osm::OsmUpdater::OsmUpdater(const config::Config &config) : _config(config),
                                                                  _repServer(config),
-                                                                 _odf(std::make_unique<OsmDataFetcherSparql>(OsmDataFetcherSparql(_config))
-), _latestState({}) {
+                                                                 _odf(createOsmDataFetcher(config)),
+                                                                 _latestState({}) {
     try {
         std::filesystem::create_directory(cnst::PATH_TO_TEMP_DIR);
         std::filesystem::create_directory(cnst::PATH_TO_CHANGE_FILE_DIR);

--- a/src/osm/ReferencesHandler.cpp
+++ b/src/osm/ReferencesHandler.cpp
@@ -67,7 +67,7 @@ void olu::osm::ReferencesHandler::getReferencesForRelations(const std::set<id_t>
                 relationIds,
                 _config.batchSize,
                 [this](const std::set<id_t>& batch) {
-                auto [nodeIds, wayIds] = _odf.fetchRelationMembers(batch);
+                auto [nodeIds, wayIds] = _odf->fetchRelationMembers(batch);
                 for (const auto &wayId: wayIds) {
                     _referencedWays.insert(wayId);
                 }
@@ -85,7 +85,7 @@ void olu::osm::ReferencesHandler::getReferencesForWays(const std::set<id_t> &way
         wayIds,
         _config.batchSize,
         [this](const std::set<id_t>& batch) {
-            for (const auto &nodeId: _odf.fetchWaysMembers(batch)) {
+            for (const auto &nodeId: _odf->fetchWaysMembers(batch)) {
                 _referencedNodes.insert(nodeId);
             }
         });

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -75,7 +75,7 @@ void olu::osm::RelationHandler::checkRelationsForMemberChange(
             continue;
         }
 
-        const auto membersEndpoint = _odf.fetchRelsMembersSorted({relId});
+        const auto membersEndpoint = _odf->fetchRelsMembersSorted({relId});
         if (membersEndpoint.empty()) {
             _createdRelations.insert(relId);
             continue;

--- a/src/osm/StatisticsHandler.cpp
+++ b/src/osm/StatisticsHandler.cpp
@@ -1,0 +1,262 @@
+// Copyright 2025, University of Freiburg
+// Authors: Nicolas von Trott <nicolasvontrott@gmail.com>.
+
+// This file is part of osm-live-updates.
+//
+// osm-live-updates is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm-live-updates is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm-live-updates.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "osm/StatisticsHandler.h"
+
+#include <iostream>
+#include <util/Time.h>
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printCurrentStep(const std::string &stepDescription) const {
+    std::cout << util::currentTimeFormatted()
+              << stepDescription
+              << std::endl;
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printOsmStatistics() const {
+    printCurrentStep("OSM Statistics:");
+
+    if (numOfNodes() == 0) {
+        std::cout << "0 nodes in change file." << std::endl;
+    } else {
+        std::cout << "nodes created: " << _numOfCreatedNodes
+                  << ", modified: " << _numOfModifiedNodes
+                  << ", deleted: " << _numOfDeletedNodes
+                  << std::endl;
+    }
+
+    if (numOfWays() == 0) {
+        std::cout << "0 ways in change file." << std::endl;
+    } else {
+        std::cout << "ways created: " << _numOfCreatedWays
+                  << ", modified: " << _numOfModifiedWays
+                  << ", deleted: " << _numOfDeletedWays
+                  << std::endl;
+    }
+
+    if (numOfRelations() == 0) {
+        std::cout << "0 relations in change file." << std::endl;
+    } else {
+        std::cout << "relations created: " << _numOfCreatedRelations
+                  << ", modified: " << _numOfModifiedRelations
+                  << ", deleted: " << _numOfDeletedRelations
+                  << std::endl;
+    }
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printUpdateStatistics() const {
+    printCurrentStep("Update Statistics:");
+    std::cout << std::fixed << std::setprecision(config::Config::DEFAULT_PERCENTAGE_PRECISION);
+
+    if (_config.showDetailedStatistics) {
+        if (_numOfNodesWithLocationChange == 0) {
+            std::cout << "No nodes with location change." << std::endl;
+        } else {
+            std::cout << _numOfNodesWithLocationChange
+                      << " modified nodes changed their location ("
+                      << calculatePercentage(_numOfModifiedNodes, _numOfNodesWithLocationChange)
+                      << "%)"
+                      << std::endl;
+        }
+
+        if (_numOfWaysWithMemberChange == 0) {
+            std::cout << "No ways with member change." << std::endl;
+        } else {
+            std::cout << _numOfWaysWithMemberChange
+                      << " modified ways have changed a member ("
+                      << calculatePercentage(_numOfModifiedWays, _numOfWaysWithMemberChange)
+                      << "%)"
+                      << std::endl;
+        }
+
+        if (_numOfRelationsWithMemberChange == 0) {
+            std::cout << "No Relations with member change." << std::endl;
+        } else {
+            std::cout << _numOfRelationsWithMemberChange
+                      << "% of modified relations have changed a member ("
+                      << calculatePercentage(_numOfModifiedRelations, _numOfRelationsWithMemberChange)
+                      << "%)"
+                      << std::endl;
+        }
+    }
+
+    if (_numOfRelationsToUpdateGeometry == 0 && _numOfWaysToUpdateGeometry == 0) {
+        std::cout << "No geometries to update" << std::endl;
+    } else {
+        std::cout << "Updated geometries for " << _numOfWaysToUpdateGeometry
+                  << " ways and " << _numOfRelationsToUpdateGeometry
+                  << " relations"
+                  << std::endl;
+    }
+
+    if (_config.showDetailedStatistics) {
+        if (_numOfDummyNodes == 0 && _numOfDummyWays == 0 && _numOfDummyRelations == 0) {
+            std::cout << "No references to nodes, ways or relations needed." << std::endl;
+        } else {
+            std::cout << "Created dummys for "
+                      << _numOfDummyNodes << " nodes, "
+                      << _numOfDummyWays << " ways, "
+                      << _numOfDummyRelations << " relations"
+                      << std::endl;
+        }
+    }
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printOsm2RdfStatistics() const {
+    printCurrentStep("Osm2Rdf Statistics:");
+
+    std::cout << "Osm2Rdf converted the OSM objects into "
+              << _numOfConvertedTriples << " triples"
+              << std::endl;
+
+    std::cout << _numOfTriplesToInsert
+              << " of them where inserted into the database."
+              << std::endl;
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printSparqlStatistics() const {
+    printCurrentStep("SPARQL Statistics:");
+
+    std::cout << _queriesCount << " SPARQL queries and "
+          << _updateQueriesCount << " update queries were send to the endpoint."
+          << std::endl;
+
+    if (_config.isQLever) {
+        std::cout << "QLever response time: " << _qleverResponseTimeMs << " ms, "
+                  << "QLever update time: " << _qleverUpdateTimeMs << " ms" << std::endl;
+    }
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::printTimingStatistics() const {
+    printCurrentStep("Timing Statistics:");
+
+    std::cout << std::fixed << std::setprecision(config::Config::DEFAULT_PERCENTAGE_PRECISION);
+    std::cout << "The complete update process took "
+            << getTimeInMSTotal()
+            << " ms." << std::endl;
+
+    if (!_config.showDetailedStatistics) {
+        return;
+    }
+
+    long partTime;
+    if (_config.changeFileDir.empty()) {
+        partTime = getTimeInMSDeterminingSequenceNumber();
+        std::cout << "Determining sequence number took "
+                << time
+                << " ms. ("
+                << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+                << std::endl;
+
+        partTime = getTimeInMSFetchingChangeFiles();
+        std::cout << "Fetching change files took "
+                << partTime
+                << " ms. ("
+                << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+                << std::endl;
+    }
+
+    partTime = getTimeInMSMergingChangeFiles();
+    std::cout << "Merging change files took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSProcessingChangeFiles();
+    std::cout << "Processing the change files took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSCheckingNodeLocations();
+    std::cout << "Checking nodes for location change took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSCheckingWayMembers();
+    std::cout << "Checking ways for member change took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSCheckingRelationMembers();
+    std::cout << "Checking relations for member change took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSFetchingObjectsToUpdateGeo();
+    std::cout << "Fetching objects to update geometry for took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSFetchingReferences();
+    std::cout << "Fetching references took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSCreatingDummys();
+    std::cout << "Creating dummy objects took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSOsm2RdfConversion();
+    std::cout << "Osm2rdf conversion took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSDeletingTriples();
+    std::cout << "Deleting triples took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSInsertingTriples();
+    std::cout << "Inserting triples took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+
+    partTime = getTimeInMSFilteringTriples();
+    std::cout << "Filtering the triples took "
+            << partTime
+            << " ms. ("
+            << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+            << std::endl;
+}

--- a/src/osm/StatisticsHandler.cpp
+++ b/src/osm/StatisticsHandler.cpp
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <util/Time.h>
 
+static inline constexpr std::string_view prefix = "                          ";
+
 // _________________________________________________________________________________________________
 void olu::osm::StatisticsHandler::printCurrentStep(const std::string &stepDescription) const {
     std::cout << util::currentTimeFormatted()
@@ -33,27 +35,27 @@ void olu::osm::StatisticsHandler::printOsmStatistics() const {
     printCurrentStep("OSM Statistics:");
 
     if (numOfNodes() == 0) {
-        std::cout << "0 nodes in change file." << std::endl;
+        std::cout << prefix << "0 nodes in change file." << std::endl;
     } else {
-        std::cout << "nodes created: " << _numOfCreatedNodes
+        std::cout << prefix << "Nodes created: " << _numOfCreatedNodes
                   << ", modified: " << _numOfModifiedNodes
                   << ", deleted: " << _numOfDeletedNodes
                   << std::endl;
     }
 
     if (numOfWays() == 0) {
-        std::cout << "0 ways in change file." << std::endl;
+        std::cout << prefix << "0 ways in change file." << std::endl;
     } else {
-        std::cout << "ways created: " << _numOfCreatedWays
+        std::cout << prefix << "Ways created: " << _numOfCreatedWays
                   << ", modified: " << _numOfModifiedWays
                   << ", deleted: " << _numOfDeletedWays
                   << std::endl;
     }
 
     if (numOfRelations() == 0) {
-        std::cout << "0 relations in change file." << std::endl;
+        std::cout << prefix << "0 relations in change file." << std::endl;
     } else {
-        std::cout << "relations created: " << _numOfCreatedRelations
+        std::cout << prefix << "Relations created: " << _numOfCreatedRelations
                   << ", modified: " << _numOfModifiedRelations
                   << ", deleted: " << _numOfDeletedRelations
                   << std::endl;
@@ -67,9 +69,9 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
 
     if (_config.showDetailedStatistics) {
         if (_numOfNodesWithLocationChange == 0) {
-            std::cout << "No nodes with location change." << std::endl;
+            std::cout << prefix << "No nodes with location change." << std::endl;
         } else {
-            std::cout << _numOfNodesWithLocationChange
+            std::cout << prefix << _numOfNodesWithLocationChange
                       << " modified nodes changed their location ("
                       << calculatePercentage(_numOfModifiedNodes, _numOfNodesWithLocationChange)
                       << "%)"
@@ -77,9 +79,9 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
         }
 
         if (_numOfWaysWithMemberChange == 0) {
-            std::cout << "No ways with member change." << std::endl;
+            std::cout << prefix << "No ways with member change." << std::endl;
         } else {
-            std::cout << _numOfWaysWithMemberChange
+            std::cout << prefix << _numOfWaysWithMemberChange
                       << " modified ways have changed a member ("
                       << calculatePercentage(_numOfModifiedWays, _numOfWaysWithMemberChange)
                       << "%)"
@@ -87,10 +89,10 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
         }
 
         if (_numOfRelationsWithMemberChange == 0) {
-            std::cout << "No Relations with member change." << std::endl;
+            std::cout << prefix << "No Relations with member change." << std::endl;
         } else {
-            std::cout << _numOfRelationsWithMemberChange
-                      << "% of modified relations have changed a member ("
+            std::cout << prefix << _numOfRelationsWithMemberChange
+                      << " of modified relations have changed a member ("
                       << calculatePercentage(_numOfModifiedRelations, _numOfRelationsWithMemberChange)
                       << "%)"
                       << std::endl;
@@ -98,9 +100,9 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
     }
 
     if (_numOfRelationsToUpdateGeometry == 0 && _numOfWaysToUpdateGeometry == 0) {
-        std::cout << "No geometries to update" << std::endl;
+        std::cout << prefix << "No geometries to update" << std::endl;
     } else {
-        std::cout << "Updated geometries for " << _numOfWaysToUpdateGeometry
+        std::cout << prefix << "Updated geometries for " << _numOfWaysToUpdateGeometry
                   << " ways and " << _numOfRelationsToUpdateGeometry
                   << " relations"
                   << std::endl;
@@ -108,9 +110,9 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
 
     if (_config.showDetailedStatistics) {
         if (_numOfDummyNodes == 0 && _numOfDummyWays == 0 && _numOfDummyRelations == 0) {
-            std::cout << "No references to nodes, ways or relations needed." << std::endl;
+            std::cout << prefix << "No references to nodes, ways or relations needed." << std::endl;
         } else {
-            std::cout << "Created dummys for "
+            std::cout << prefix << "Created dummys for "
                       << _numOfDummyNodes << " nodes, "
                       << _numOfDummyWays << " ways, "
                       << _numOfDummyRelations << " relations"
@@ -123,12 +125,12 @@ void olu::osm::StatisticsHandler::printUpdateStatistics() const {
 void olu::osm::StatisticsHandler::printOsm2RdfStatistics() const {
     printCurrentStep("Osm2Rdf Statistics:");
 
-    std::cout << "Osm2Rdf converted the OSM objects into "
+    std::cout << prefix << "Osm2Rdf converted the OSM objects into "
               << _numOfConvertedTriples << " triples"
               << std::endl;
 
-    std::cout << _numOfTriplesToInsert
-              << " of them where inserted into the database."
+    std::cout << prefix << _numOfTriplesToInsert
+              << " of them are relevant for the update."
               << std::endl;
 }
 
@@ -136,12 +138,12 @@ void olu::osm::StatisticsHandler::printOsm2RdfStatistics() const {
 void olu::osm::StatisticsHandler::printSparqlStatistics() const {
     printCurrentStep("SPARQL Statistics:");
 
-    std::cout << _queriesCount << " SPARQL queries and "
+    std::cout << prefix << _queriesCount << " SPARQL queries and "
           << _updateQueriesCount << " update queries were send to the endpoint."
           << std::endl;
 
     if (_config.isQLever) {
-        std::cout << "QLever response time: " << _qleverResponseTimeMs << " ms, "
+        std::cout << prefix << "QLever response time: " << _qleverResponseTimeMs << " ms, "
                   << "QLever update time: " << _qleverUpdateTimeMs << " ms" << std::endl;
     }
 }
@@ -151,7 +153,7 @@ void olu::osm::StatisticsHandler::printTimingStatistics() const {
     printCurrentStep("Timing Statistics:");
 
     std::cout << std::fixed << std::setprecision(config::Config::DEFAULT_PERCENTAGE_PRECISION);
-    std::cout << "The complete update process took "
+    std::cout << prefix << "The complete update process took "
             << getTimeInMSTotal()
             << " ms." << std::endl;
 
@@ -162,14 +164,14 @@ void olu::osm::StatisticsHandler::printTimingStatistics() const {
     long partTime;
     if (_config.changeFileDir.empty()) {
         partTime = getTimeInMSDeterminingSequenceNumber();
-        std::cout << "Determining sequence number took "
-                << time
+        std::cout << prefix << "Determining sequence number took "
+                << partTime
                 << " ms. ("
                 << calculatePercentageOfTotalTime(partTime) << "% of total time)"
                 << std::endl;
 
         partTime = getTimeInMSFetchingChangeFiles();
-        std::cout << "Fetching change files took "
+        std::cout << prefix << "Fetching change files took "
                 << partTime
                 << " ms. ("
                 << calculatePercentageOfTotalTime(partTime) << "% of total time)"
@@ -177,84 +179,84 @@ void olu::osm::StatisticsHandler::printTimingStatistics() const {
     }
 
     partTime = getTimeInMSMergingChangeFiles();
-    std::cout << "Merging change files took "
+    std::cout << prefix << "Merging change files took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSProcessingChangeFiles();
-    std::cout << "Processing the change files took "
+    std::cout << prefix << "Processing the change files took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSCheckingNodeLocations();
-    std::cout << "Checking nodes for location change took "
+    std::cout << prefix << "Checking nodes for location change took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSCheckingWayMembers();
-    std::cout << "Checking ways for member change took "
+    std::cout << prefix << "Checking ways for member change took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSCheckingRelationMembers();
-    std::cout << "Checking relations for member change took "
+    std::cout << prefix << "Checking relations for member change took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSFetchingObjectsToUpdateGeo();
-    std::cout << "Fetching objects to update geometry for took "
+    std::cout << prefix << "Fetching objects to update geometry for took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSFetchingReferences();
-    std::cout << "Fetching references took "
+    std::cout << prefix << "Fetching references took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSCreatingDummys();
-    std::cout << "Creating dummy objects took "
+    std::cout << prefix << "Creating dummy objects took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSOsm2RdfConversion();
-    std::cout << "Osm2rdf conversion took "
+    std::cout << prefix << "Osm2rdf conversion took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSDeletingTriples();
-    std::cout << "Deleting triples took "
+    std::cout << prefix << "Deleting triples took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSInsertingTriples();
-    std::cout << "Inserting triples took "
+    std::cout << prefix << "Inserting triples took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
 
     partTime = getTimeInMSFilteringTriples();
-    std::cout << "Filtering the triples took "
+    std::cout << prefix << "Filtering the triples took "
             << partTime
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"

--- a/src/osm/StatisticsHandler.cpp
+++ b/src/osm/StatisticsHandler.cpp
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <util/Time.h>
 
+#include "config/Constants.h"
+
 static inline constexpr std::string_view prefix = "                          ";
 
 // _________________________________________________________________________________________________
@@ -261,4 +263,34 @@ void olu::osm::StatisticsHandler::printTimingStatistics() const {
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::countQleverResponseTime(const std::string_view &timeInMs) {
+    const auto timeString = timeInMs.substr(0, timeInMs.size() - 2); // Remove trailing "ms"
+    _qleverResponseTimeMs += std::stoi(std::string(timeString));
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::countQleverUpdateTime(const std::string_view &timeInMs) {
+    const auto timeString = timeInMs.substr(0, timeInMs.size() - 2); // Remove trailing "ms"
+    _qleverUpdateTimeMs += std::stoi(std::string(timeString));
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::logQleverTimingInfoQuery(simdjson::ondemand::object timeResult) {
+    for (auto field: timeResult) {
+        if (field.key() == config::constants::KEY_QLEVER_COMPUTE_RESULT) {
+            countQleverResponseTime(field.value().value().get_string());
+        }
+    }
+}
+
+// _________________________________________________________________________________________________
+void olu::osm::StatisticsHandler::logQleverTimingInfoUpdate(simdjson::ondemand::object timeResult) {
+    for (auto field: timeResult) {
+        if (field.key() == config::constants::KEY_QLEVER_TOTAL) {
+            countQleverUpdateTime(field.value().value().get_string());
+        }
+    }
 }

--- a/src/osm/WayHandler.cpp
+++ b/src/osm/WayHandler.cpp
@@ -73,7 +73,7 @@ void olu::osm::WayHandler::checkWaysForMemberChange(
             continue;
         }
 
-        const auto &membersEndpoint =  _odf.fetchWaysMembersSorted({wayId});
+        const auto &membersEndpoint =  _odf->fetchWaysMembersSorted({wayId});
         if (membersEndpoint.empty()) {
             _createdWays.insert(wayId);
             continue;

--- a/src/sparql/SparqlWrapper.cpp
+++ b/src/sparql/SparqlWrapper.cpp
@@ -91,8 +91,8 @@ std::string olu::sparql::SparqlWrapper::send(const bool isUpdate) {
 }
 
 // _________________________________________________________________________________________________
-void olu::sparql::SparqlWrapper::runUpdate() {
-    send(true);
+std::string olu::sparql::SparqlWrapper::runUpdate() {
+    return send(true);
 }
 
 // _________________________________________________________________________________________________

--- a/src/sparql/SparqlWrapper.cpp
+++ b/src/sparql/SparqlWrapper.cpp
@@ -43,11 +43,18 @@ void olu::sparql::SparqlWrapper::setPrefixes(const std::vector<std::string> &pre
 }
 
 // _________________________________________________________________________________________________
-std::string olu::sparql::SparqlWrapper::send(const std::string& acceptValue, const bool isUpdate) {
+std::string olu::sparql::SparqlWrapper::send(const bool isUpdate) {
     if (_config.sparqlOutput == config::SparqlOutput::DEBUG_FILE ||
         (_config.sparqlOutput == config::SparqlOutput::FILE && isUpdate)) {
         writeQueryToFileOutput();
     }
+
+    // Set the accept-value depending on whether we are using QLever or not.
+    // QLever endpoints will return metadata with the results, while SPARQL results will only
+    // include the actual data.
+    const auto acceptValue = _config.isQLever
+                                 ? cnst::HTML_VALUE_ACCEPT_QLEVER_RESULT_JSON
+                                 : cnst::HTML_VALUE_ACCEPT_SPARQL_RESULT_JSON;
 
     // Format and encode query
     const std::string query = _prefixes + _query;
@@ -85,12 +92,12 @@ std::string olu::sparql::SparqlWrapper::send(const std::string& acceptValue, con
 
 // _________________________________________________________________________________________________
 void olu::sparql::SparqlWrapper::runUpdate() {
-    send(cnst::HTML_VALUE_ACCEPT_SPARQL_RESULT_JSON, true);
+    send(true);
 }
 
 // _________________________________________________________________________________________________
 std::string olu::sparql::SparqlWrapper::runQuery() {
-    const auto response = send(cnst::HTML_VALUE_ACCEPT_SPARQL_RESULT_JSON, false);
+    const auto response = send(false);
 
     if (response.empty()) {
         throw SparqlWrapperException("Empty response from SPARQL endpoint");

--- a/src/util/XmlHelper.cpp
+++ b/src/util/XmlHelper.cpp
@@ -18,6 +18,7 @@
 
 #include "util/XmlHelper.h"
 
+#include <iostream>
 #include <string>
 
 #include "boost/regex.hpp"
@@ -97,4 +98,21 @@ std::string olu::util::XmlHelper::xmlDecode(const std::string &input) {
 
     output.append(input, prev_pos, std::string::npos);
     return output;
+}
+
+// _________________________________________________________________________________________________
+std::string olu::util::XmlHelper::parseKeyName(const std::string& uri) {
+    // Remove angle brackets if present
+    std::string clean = uri;
+    if (!clean.empty() && clean.front() == '<' && clean.back() == '>') {
+        clean = clean.substr(1, clean.size() - 2);
+    }
+
+    // Find the last colon (Key:source:population)
+    if (const size_t pos = clean.rfind("Key:"); pos != std::string::npos) {
+        return clean.substr(pos + 4);
+    }
+
+    const std::string msg = "Cannot parse key name from URI: " + uri;
+    throw XmlHelperException(msg.c_str());
 }


### PR DESCRIPTION
- Communicate with QLever endpoints via "application/qlever-results+json"
- Parallel fetching of state and change files from the replication server
- Added "--statistics" option that outputs information about more detailed stats and timing information
