### PR TITLE
Add support for bounding box and polygon filters using osmium-tool.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     git \
     libcurl4-openssl-dev \
     libomp-dev \
-    libosmium2-dev
+    libosmium2-dev \
+# Uncomment the following line if you want to add the support for bounding boxes or polygon files
+#    osmium-tool
 
 COPY . /app/
 WORKDIR /app/build/

--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -54,8 +54,13 @@ struct Config {
 
     // User specified sequence number from command line.
     int sequenceNumber = -1;
-    // User specified timestamp from command line
+    // User specified timestamp from the command line
     std::string timestamp;
+
+    // User specified bounding box in the form of "LEFT, BOTTOM, RIGHT, TOP"
+    std::string bbox;
+    // User specified path to a polygon file
+    std::string pathToPolygonFile;
 
     int numThreads = std::thread::hardware_concurrency();
 

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -56,6 +56,7 @@ namespace olu::config::constants {
 
     // File paths ----------------------------------------------------------------------------------
     const static inline std::string PATH_TO_CHANGE_FILE = PATH_TO_TEMP_DIR + "changes" + OSM_CHANGE_FILE_EXTENSION + GZIP_EXTENSION;
+    const static inline std::string PATH_TO_CHANGE_FILE_EXTRACT = PATH_TO_TEMP_DIR + "changes-boundary" + OSM_CHANGE_FILE_EXTENSION + GZIP_EXTENSION;
     const static inline std::string PATH_TO_INPUT_FILE = PATH_TO_TEMP_DIR + "input" + OSM_EXTENSION;
     const static inline std::string PATH_TO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "output" + TURTLE_FILE_EXTENSION;
     const static inline std::string PATH_TO_OSM2RDF_INFO_OUTPUT_FILE = PATH_TO_TEMP_DIR + "osm2rdf_info" + TEXT_FILE_EXTENSION;
@@ -460,6 +461,18 @@ namespace olu::config::constants {
     const static inline std::string STATISTICS_OPTION_LONG = "statistics";
     const static inline std::string STATISTICS_OPTION_HELP =
         "Specify if detailed statistics should be added to the output.";
+
+    const static inline std::string BBOX_INFO = "Using bounding box: ";
+    const static inline std::string BBOX_OPTION_SHORT = "b";
+    const static inline std::string BBOX_OPTION_LONG = "bbox";
+    const static inline std::string BBOX_OPTION_HELP =
+         "Specify a bounding box (LEFT,BOTTOM,RIGHT,TOP) to cut out a specific area from the change files. ";
+
+    const static inline std::string POLY_FILE_INFO = "Using (multi)polygon file at: ";
+    const static inline std::string POLY_FILE_OPTION_SHORT = "p";
+    const static inline std::string POLY_FILE_OPTION_LONG = "polygon";
+    const static inline std::string POLY_FILE_OPTION_HELP =
+         "Specify a (multi)polygon file (.poly) to cut out a specific area from the change files. ";
 
 } // namespace olu::config::constants
 

--- a/include/config/ExitCode.h
+++ b/include/config/ExitCode.h
@@ -33,7 +33,9 @@ namespace olu::config {
         ENDPOINT_UPDATE_URI_INVALID,
         GRAPH_URI_INVALID,
         INPUT_NOT_EXISTS,
-        INPUT_IS_NOT_DIRECTORY
+        INPUT_IS_NOT_DIRECTORY,
+        POLYGON_FILE_NOT_EXISTS,
+        BBOX_INVALID
     };
 
 }

--- a/include/osm/OsmUpdater.h
+++ b/include/osm/OsmUpdater.h
@@ -106,6 +106,12 @@ namespace olu::osm {
          * run of olu.
          */
         void insertMetadataTriples(OsmChangeHandler &och);
+
+        /**
+         * Applies the user-specified bounding box or polygon to the change files,
+         * by using the 'extract' option from the 'osmium-tool'
+         */
+        void applyBoundaries() const;
     };
 
     /**

--- a/include/osm/StatisticsHandler.h
+++ b/include/osm/StatisticsHandler.h
@@ -58,6 +58,12 @@ namespace olu::osm {
             return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeMergingChangeFiles - _startTimeMergingChangeFiles).count();
         }
 
+        void startTimeApplyingBoundaries() { _startTimeApplyingBoundaries = std::chrono::system_clock::now(); }
+        void endTimeApplyingBoundaries() { _endTimeApplyingBoundaries = std::chrono::system_clock::now(); }
+        long getTimeInMSApplyingBoundaries() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(_endTimeApplyingBoundaries - _startTimeApplyingBoundaries).count();
+        }
+
         void startTimeFetchingChangeFiles() { _startTimeFetchingChangeFiles = std::chrono::system_clock::now(); }
         void endTimeFetchingChangeFiles() { _endTimeFetchingChangeFiles = std::chrono::system_clock::now(); }
         long getTimeInMSFetchingChangeFiles() const {
@@ -242,6 +248,9 @@ namespace olu::osm {
 
         time_point_t _startTimeMergingChangeFiles;
         time_point_t _endTimeMergingChangeFiles;
+
+        time_point_t _startTimeApplyingBoundaries;
+        time_point_t _endTimeApplyingBoundaries;
 
         time_point_t _startTimeFetchingChangeFiles;
         time_point_t _endTimeFetchingChangeFiles;

--- a/src/osm/StatisticsHandler.cpp
+++ b/src/osm/StatisticsHandler.cpp
@@ -153,7 +153,8 @@ void olu::osm::StatisticsHandler::printSparqlStatistics() const {
             util::Logger::stream() << PREFIX_SPACER << "Inserted: " << _qleverInsertedTriplesCount << " and deleted "
                       << _qleverDeletedTriplesCount << " triples at QLever endpoint" << std::endl;
 
-            if (_qleverInsertedTriplesCount != _numOfTriplesToInsert) {
+            // Add the two metadata triples that are inserted at the end of the update process.
+            if (_qleverInsertedTriplesCount != _numOfTriplesToInsert + 2) {
                 util::Logger::log(util::LogEvent::WARNING, "The number of triples inserted"
                                   " at the end point is not equal to the"
                                   " number of triples that need to be"
@@ -201,6 +202,15 @@ void olu::osm::StatisticsHandler::printTimingStatistics() const {
             << " ms. ("
             << calculatePercentageOfTotalTime(partTime) << "% of total time)"
             << std::endl;
+
+    if (!_config.bbox.empty() || !_config.pathToPolygonFile.empty()) {
+        partTime = getTimeInMSApplyingBoundaries();
+        util::Logger::stream() << PREFIX_SPACER << "Applying boundaries took "
+                << partTime
+                << " ms. ("
+                << calculatePercentageOfTotalTime(partTime) << "% of total time)"
+                << std::endl;
+    }
 
     partTime = getTimeInMSProcessingChangeFiles();
     util::Logger::stream() << PREFIX_SPACER << "Processing the change files took "


### PR DESCRIPTION
Added new configuration options for specifying a bounding box (`--bbox`) or a polygon file (`--polygon`). 

Osmiums 'extract' tool is used for this purpose and must therefore be installed if these options are used. See https://docs.osmcode.org/osmium/latest/osmium-extract.html for more details
