### PR TITLE
Optimised latest timestamp query

### DIFF
--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -234,9 +234,11 @@ namespace olu::config::constants {
     const static inline std::string NAME_URI = "uri";
     const static inline std::string NAME_LOCATION = "location";
     const static inline std::string NAME_TIMESTAMP = "timestamp";
+    const static inline std::string NAME_LATEST_TIMESTAMP = "latestTimestamp";
     const static inline std::string NAME_VERSION = "version";
     const static inline std::string NAME_CHANGESET = "changeset";
     const static inline std::string NAME_OSM_NODE_ = "osm_node_";
+    const static inline std::string NAME_OBJECT = "object";
     const static inline std::string NAME_NODE = "node";
     const static inline std::string NAME_NODES = "nodes";
     const static inline std::string NAME_WAY = "way";
@@ -367,8 +369,10 @@ namespace olu::config::constants {
     const static inline std::string QUERY_VAR_VAL = MakeQueryVar(NAME_VALUE);
     const static inline std::string QUERY_VAR_LOC = MakeQueryVar(NAME_LOCATION);
     const static inline std::string QUERY_VAR_TIMESTAMP = MakeQueryVar(NAME_TIMESTAMP);
+    const static inline std::string QUERY_VAR_LATEST_TIMESTAMP = MakeQueryVar(NAME_LATEST_TIMESTAMP);
     const static inline std::string QUERY_VAR_VERSION = MakeQueryVar(NAME_VERSION);
     const static inline std::string QUERY_VAR_CHANGESET = MakeQueryVar(NAME_CHANGESET);
+    const static inline std::string QUERY_VAR_OBJECT = MakeQueryVar(NAME_OBJECT);
     const static inline std::string QUERY_VAR_NODE = MakeQueryVar(NAME_NODE);
     const static inline std::string QUERY_VAR_WAY = MakeQueryVar(NAME_WAY);
     const static inline std::string QUERY_VAR_REL = MakeQueryVar(NAME_REL);

--- a/include/config/Constants.h
+++ b/include/config/Constants.h
@@ -312,8 +312,8 @@ namespace olu::config::constants {
     const static inline std::vector PREFIXES_FOR_RELATION_TAGS_AND_META_INFO{
             PREFIX_DECL_OSM_REL, PREFIX_DECL_OSM_META, PREFIX_DECL_OSM_KEY};
 
-    const static inline std::vector PREFIXES_FOR_LATEST_NODE_TIMESTAMP {
-            PREFIX_DECL_OSM_META, PREFIX_DECL_OSM, PREFIX_DECL_RDF};
+    const static inline std::vector PREFIXES_FOR_LATEST_TIMESTAMP {
+            PREFIX_DECL_OSM_META };
 
     const static inline std::vector PREFIXES_FOR_NODE_DELETE_QUERY {
             PREFIX_DECL_OSM_NODE, PREFIX_DECL_GEO};

--- a/include/osm/OsmDataFetcher.h
+++ b/include/osm/OsmDataFetcher.h
@@ -156,11 +156,12 @@ namespace olu::osm {
         fetchRelationMembers(const std::set<id_t> &relIds){return {};}
 
         /**
-         * Sends a query to the sparql endpoint to the latest timestamp of any node in the database
+         * Sends a query to the sparql endpoint to fetch the latest timestamp for the predicate
+         * 'osmmeta:timestamp', which is the latest timestamp of all OSM objects in the database.
          *
-         * @return The latest timestamp of any node
+         * @return The latest timestamp for the predicate 'osmmeta:timestamp'
          */
-        virtual std::string fetchLatestTimestampOfAnyNode(){return {};}
+        virtual std::string fetchLatestTimestamp(){return {};}
 
         /**
          * @return The ids of all ways that reference the given nodes.

--- a/include/osm/OsmDataFetcherQLever.h
+++ b/include/osm/OsmDataFetcherQLever.h
@@ -52,7 +52,7 @@ namespace olu::osm {
         std::pair<std::vector<id_t>, std::vector<id_t>>
         fetchRelationMembers(const std::set<id_t> &relIds) override;
 
-        std::string fetchLatestTimestampOfAnyNode() override;
+        std::string fetchLatestTimestamp() override;
 
         std::vector<id_t> fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) override;
 

--- a/include/osm/OsmDataFetcherSparql.h
+++ b/include/osm/OsmDataFetcherSparql.h
@@ -52,7 +52,7 @@ namespace olu::osm {
         std::pair<std::vector<id_t>, std::vector<id_t>>
         fetchRelationMembers(const std::set<id_t> &relIds) override;
 
-        std::string fetchLatestTimestampOfAnyNode() override;
+        std::string fetchLatestTimestamp() override;
 
         std::vector<id_t> fetchWaysReferencingNodes(const std::set<id_t> &nodeIds) override;
 

--- a/include/sparql/QueryWriter.h
+++ b/include/sparql/QueryWriter.h
@@ -86,9 +86,9 @@ namespace olu::sparql {
         [[nodiscard]] std::string writeQueryForNodeLocations(const std::set<id_t> &nodeIds) const;
 
         /**
-         * @returns A SPARQL query for the latest timestamp of any node in the database
+         * @returns A SPARQL query for the latest timestamp for the predicate 'osmmeta:timestamp'
          */
-        [[nodiscard]] std::string writeQueryForLatestNodeTimestamp() const;
+        [[nodiscard]] std::string writeQueryForLatestTimestamp() const;
 
         /**
         * @returns A SPARQL query for the subject of all members, that belong to the given relation

--- a/src/osm/OsmDataFetcherQLever.cpp
+++ b/src/osm/OsmDataFetcherQLever.cpp
@@ -68,10 +68,10 @@ void olu::osm::OsmDataFetcherQLever::runQuery(const std::string &query,
 }
 
 // _________________________________________________________________________________________________
-std::string olu::osm::OsmDataFetcherQLever::fetchLatestTimestampOfAnyNode() {
+std::string olu::osm::OsmDataFetcherQLever::fetchLatestTimestamp() {
     std::string timestamp;
-    runQuery(_queryWriter.writeQueryForLatestNodeTimestamp(),
-             cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP,
+    runQuery(_queryWriter.writeQueryForLatestTimestamp(),
+             cnst::PREFIXES_FOR_LATEST_TIMESTAMP,
              [&timestamp](simdjson::ondemand::value results) {
                  for (auto value: results) {
                      // QLever will return the timestamp in rdf syntax, e.g.:

--- a/src/osm/OsmDataFetcherSparql.cpp
+++ b/src/osm/OsmDataFetcherSparql.cpp
@@ -521,7 +521,7 @@ std::string olu::osm::OsmDataFetcherSparql::fetchOsm2RdfVersion() {
     for (auto doc = _parser.iterate(response);
         auto binding : getBindings(doc)) {
         auto version = getValue<std::string>(binding[cnst::NAME_VALUE]);
-        versions.insert(util::XmlHelper::parseRdfString<std::string>(version));
+        versions.insert(version);
     }
 
     if (versions.size() == 0) {
@@ -547,8 +547,7 @@ std::map<std::string, std::string> olu::osm::OsmDataFetcherSparql::fetchOsm2RdfO
         const auto optionIRI =  getValue<std::string_view>(binding[cnst::NAME_OPTION]);
         const auto optionValue = getValue<std::string>(binding[cnst::NAME_VALUE]);
 
-        options.insert_or_assign(OsmObjectHelper::parseOsm2rdfOptionName(optionIRI),
-                                 util::XmlHelper::parseRdfString<std::string>(optionValue));
+        options.insert_or_assign(OsmObjectHelper::parseOsm2rdfOptionName(optionIRI), optionValue);
     }
 
     return options;

--- a/src/osm/OsmDataFetcherSparql.cpp
+++ b/src/osm/OsmDataFetcherSparql.cpp
@@ -107,14 +107,14 @@ void olu::osm::OsmDataFetcherSparql::fetchAndWriteNodesToFile(const std::string 
 }
 
 // _________________________________________________________________________________________________
-std::string olu::osm::OsmDataFetcherSparql::fetchLatestTimestampOfAnyNode() {
+std::string olu::osm::OsmDataFetcherSparql::fetchLatestTimestamp() {
     const auto response = runQuery(
-        _queryWriter.writeQueryForLatestNodeTimestamp(),
-        cnst::PREFIXES_FOR_LATEST_NODE_TIMESTAMP);
+        _queryWriter.writeQueryForLatestTimestamp(),
+        cnst::PREFIXES_FOR_LATEST_TIMESTAMP);
 
     std::string timestamp;
     const auto error = _parser.iterate(response).at_path(
-        "$.results.bindings[0].timestamp.value").get_string(timestamp);
+        "$.results.bindings[0].latestTimestamp.value").get_string(timestamp);
     if (error || timestamp.empty()) {
         std::cerr << "JSON error: " << error << std::endl;
         throw OsmDataFetcherException("Could not parse latest timestamp of any node from "

--- a/src/osm/OsmUpdater.cpp
+++ b/src/osm/OsmUpdater.cpp
@@ -210,12 +210,12 @@ void olu::osm::OsmUpdater::decideStartSequenceNumber() {
         // node timestamp
     }
 
-    // Check SPARQL endpoint for the latest node timestamp
+    // Check for the latest timestamp of any OSM object on the SPARQL endpoint
     util::Logger::log(util::LogEvent::INFO,
-                      "Fetch latest node-timestamp on SPARQL endpoint...");
-    const std::string timestamp = _odf->fetchLatestTimestampOfAnyNode();
+                      "Fetch latest timestamp on SPARQL endpoint...");
+    const std::string timestamp = _odf->fetchLatestTimestamp();
     util::Logger::log(util::LogEvent::INFO,
-                      "Latest node-timestamp on SPARQL endpoint is: " + timestamp);
+                      "Latest timestamp on SPARQL endpoint is: " + timestamp);
     _repServer.fetchDatabaseStateForTimestamp(timestamp);
 }
 

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -278,7 +278,7 @@ olu::sparql::QueryWriter::writeQueryForNodeLocations(const std::set<id_t> &nodeI
 }
 
 // _________________________________________________________________________________________________
-std::string olu::sparql::QueryWriter::writeQueryForLatestNodeTimestamp() const {
+std::string olu::sparql::QueryWriter::writeQueryForLatestTimestamp() const {
     std::ostringstream oss;
     oss << "SELECT (MAX(" + cnst::QUERY_VAR_TIMESTAMP + ") AS " + cnst::QUERY_VAR_LATEST_TIMESTAMP + ") ";
     oss << getFromClauseOptional();

--- a/src/sparql/QueryWriter.cpp
+++ b/src/sparql/QueryWriter.cpp
@@ -280,12 +280,11 @@ olu::sparql::QueryWriter::writeQueryForNodeLocations(const std::set<id_t> &nodeI
 // _________________________________________________________________________________________________
 std::string olu::sparql::QueryWriter::writeQueryForLatestNodeTimestamp() const {
     std::ostringstream oss;
-    oss << "SELECT " + cnst::QUERY_VAR_TIMESTAMP + " ";
+    oss << "SELECT (MAX(" + cnst::QUERY_VAR_TIMESTAMP + ") AS " + cnst::QUERY_VAR_LATEST_TIMESTAMP + ") ";
     oss << getFromClauseOptional();
     oss << "WHERE { ";
-    oss << getTripleClause("?node", cnst::PREFIXED_RDF_TYPE, cnst::PREFIXED_OSM_NODE);
-    oss << getTripleClause("?node", cnst::PREFIXED_OSM_META_TIMESTAMP, cnst::QUERY_VAR_TIMESTAMP);
-    oss << "} ORDER BY DESC(" + cnst::QUERY_VAR_TIMESTAMP + ") LIMIT 1";
+    oss << getTripleClause(cnst::QUERY_VAR_OBJECT, cnst::PREFIXED_OSM_META_TIMESTAMP, cnst::QUERY_VAR_TIMESTAMP);
+    oss << "}";
     return oss.str();
 }
 

--- a/tests/sparql/QueryWriter.cpp
+++ b/tests/sparql/QueryWriter.cpp
@@ -362,10 +362,10 @@ namespace olu::sparql {
             );
         }
     }
-    TEST(QueryWriter, writeQueryForLatestNodeTimestamp) {
+    TEST(QueryWriter, writeQueryForLatestTimestamp) {
         {
             QueryWriter qw{config::Config()};
-            std::string query = qw.writeQueryForLatestNodeTimestamp();
+            std::string query = qw.writeQueryForLatestTimestamp();
             ASSERT_EQ(
             "SELECT (MAX(?timestamp) AS ?latestTimestamp) WHERE { "
             "?object osmmeta:timestamp ?timestamp . }",

--- a/tests/sparql/QueryWriter.cpp
+++ b/tests/sparql/QueryWriter.cpp
@@ -367,9 +367,9 @@ namespace olu::sparql {
             QueryWriter qw{config::Config()};
             std::string query = qw.writeQueryForLatestNodeTimestamp();
             ASSERT_EQ(
-                    "SELECT ?timestamp WHERE { ?node rdf:type osm:node . ?node osmmeta:timestamp ?timestamp . } "
-                    "ORDER BY DESC(?timestamp) LIMIT 1",
-                    query
+            "SELECT (MAX(?timestamp) AS ?latestTimestamp) WHERE { "
+            "?object osmmeta:timestamp ?timestamp . }",
+            query
             );
         }
     }


### PR DESCRIPTION
Refactor the latest timestamp query to use MAX() instead of ORDE…R BY, as this uses far less memory. In addition, the timestamp is now checked for all OSM objects and not just for nodes.

* Fixed a bug when communication via 'application/sparql-results'