### PR TITLE
Install osmium-tool by default in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
 # The osmium tool is only needed if you want to add support for bounding boxes or polygon files
-#    osmium-tool \
+    osmium-tool \
     ca-certificates \
     build-essential \
     ninja-build \


### PR DESCRIPTION
Install osmium-tool by default to make it available in the official docker image at docker.io/adfreiburg/olu